### PR TITLE
Sde dynamic stepsize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pharmsol"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 authors = ["Julián D. Otálvaro <juliandavid347@gmail.com>", "Markus Hovd"]
 description = "Rust library for solving analytic and ode-defined pharmacometric models."

--- a/examples/sde.rs
+++ b/examples/sde.rs
@@ -1,0 +1,187 @@
+use pharmsol::{prelude::data::read_pmetrics, *};
+
+fn one_c_ode() -> ODE {
+    let ode = equation::ODE::new(
+        |x, p, _t, dx, _rateiv, _cov| {
+            // fetch_cov!(cov, t, wt);
+            fetch_params!(p, ke);
+            dx[0] = -ke * x[0];
+        },
+        |_p| lag! {},
+        |_p| fa! {},
+        |_p, _t, _cov, _x| {},
+        |x, _p, _t, _cov, y| {
+            y[0] = x[0] / 50.0;
+        },
+        (1, 1),
+    );
+    ode
+}
+
+fn one_c_sde() -> SDE {
+    let sde = equation::SDE::new(
+        |x, p, _t, dx, _rateiv, _cov| {
+            // automatically defined
+            fetch_params!(p, ke0, _ske);
+            // let ke0 = 1.2;
+            dx[1] = -x[1] + ke0;
+            let ke = x[1];
+            // user defined
+            dx[0] = -ke * x[0];
+        },
+        |p, d| {
+            fetch_params!(p, _ke0, ske);
+            d[1] = ske;
+        },
+        |_p| lag! {},
+        |_p| fa! {},
+        |p, _t, _cov, x| {
+            fetch_params!(p, ke0, _ske);
+            x[1] = ke0;
+        },
+        |x, p, _t, _cov, y| {
+            fetch_params!(p, _ke0, _ske);
+            y[0] = x[0] / 50.0;
+        },
+        (2, 1),
+        2,
+    );
+    sde
+}
+
+fn three_c_ode() -> ODE {
+    let ode = equation::ODE::new(
+        |x, p, _t, dx, _rateiv, _cov| {
+            // fetch_cov!(cov, t, wt);
+            fetch_params!(p, ka, ke, kcp, kpc, _vol);
+            dx[0] = -ka * x[0];
+            dx[1] = ka * x[0] - (ke + kcp) * x[1] + kpc * x[2];
+            dx[2] = kcp * x[1] - kpc * x[2];
+        },
+        |_p| lag! {},
+        |_p| fa! {},
+        |_p, _t, _cov, _x| {},
+        |x, p, _t, _cov, y| {
+            fetch_params!(p, _ka, _ke, _kcp, _kpc, vol);
+            y[0] = x[1] / vol;
+        },
+        (3, 3),
+    );
+    ode
+}
+
+fn three_c_sde() -> SDE {
+    let sde = equation::SDE::new(
+        |x, p, _t, dx, _rateiv, _cov| {
+            fetch_params!(p, ka, ke0, kcp, kpc, _vol, _ske);
+            dx[3] = -x[3] + ke0;
+            let ke = x[3];
+            dx[0] = -ka * x[0];
+            dx[1] = ka * x[0] - (ke + kcp) * x[1] + kpc * x[2];
+            dx[2] = kcp * x[1] - kpc * x[2];
+        },
+        |p, d| {
+            fetch_params!(p, _ka, _ke0, _kcp, _kpc, _vol, ske);
+            d[3] = ske;
+        },
+        |_p| lag! {},
+        |_p| fa! {},
+        |p, _t, _cov, x| {
+            fetch_params!(p, _ka, ke0, _kcp, _kpc, _vol, _ske);
+            x[3] = ke0;
+        },
+        |x, p, _t, _cov, y| {
+            fetch_params!(p, _ka, _ke0, _kcp0, _kpc0, vol, _ske);
+            y[0] = x[1] / vol;
+        },
+        (4, 1),
+        2,
+    );
+    sde
+}
+
+fn main() {
+    let ode = one_c_ode();
+    let sde = one_c_sde();
+
+    let subject = data::Subject::builder("id1")
+        .bolus(0.0, 20.0, 0)
+        .observation(0.0, -1.0, 0)
+        .repeat(5, 0.2)
+        .build();
+
+    let ode_predictions = ode.estimate_predictions(&subject, &vec![1.0]);
+    let sde_predictions = sde.estimate_predictions(&subject, &vec![1.0, 0.0]);
+
+    let mut sde_flat_predictions: Vec<Vec<f64>> = Vec::new();
+    for trajectory in sde_predictions.rows() {
+        let mut flat_predictions: Vec<f64> = Vec::new();
+        for prediction in trajectory.iter() {
+            flat_predictions.push(prediction.prediction());
+        }
+        sde_flat_predictions.push(flat_predictions);
+    }
+    println!("One compartment model");
+    dbg!(ode_predictions.flat_predictions());
+    dbg!(sde_flat_predictions);
+    println!("---------------------------------");
+
+    let ode = three_c_ode();
+    let sde = three_c_sde();
+
+    let spp_ode = vec![
+        0.9235121835947036,
+        1.9836121537923812,
+        0.6279836881637573,
+        1.426409281349182,
+        11.543784689903259,
+    ];
+    let spp_sde = vec![
+        0.9235121835947036,
+        1.9836121537923812,
+        0.6279836881637573,
+        1.426409281349182,
+        11.543784689903259,
+        0.0,
+    ];
+
+    let ode_predictions = ode.estimate_predictions(&subject, &spp_ode);
+    let sde_predictions = sde.estimate_predictions(&subject, &spp_sde);
+
+    let mut sde_flat_predictions: Vec<Vec<f64>> = Vec::new();
+    for trajectory in sde_predictions.rows() {
+        let mut flat_predictions: Vec<f64> = Vec::new();
+        for prediction in trajectory.iter() {
+            flat_predictions.push(prediction.prediction());
+        }
+        sde_flat_predictions.push(flat_predictions);
+    }
+
+    println!("Three compartment model");
+    dbg!(ode_predictions.flat_predictions());
+    dbg!(sde_flat_predictions);
+    println!("---------------------------------");
+
+    let ode = three_c_ode();
+    let sde = three_c_sde();
+
+    let data = read_pmetrics("../PMcore/examples/w_vanco_sde/test.csv").unwrap();
+    let subject = data.get_subject("51").unwrap();
+
+    let ode_predictions = ode.estimate_predictions(&subject, &spp_ode);
+    let sde_predictions = sde.estimate_predictions(&subject, &spp_sde);
+
+    let mut sde_flat_predictions: Vec<Vec<f64>> = Vec::new();
+    for trajectory in sde_predictions.rows() {
+        let mut flat_predictions: Vec<f64> = Vec::new();
+        for prediction in trajectory.iter() {
+            flat_predictions.push(prediction.prediction());
+        }
+        sde_flat_predictions.push(flat_predictions);
+    }
+
+    println!("Three compartment model - Vanco");
+    dbg!(ode_predictions.flat_predictions());
+    dbg!(sde_flat_predictions);
+    println!("---------------------------------");
+}

--- a/src/data/structs.rs
+++ b/src/data/structs.rs
@@ -26,6 +26,10 @@ impl Data {
     pub fn add_subject(&mut self, subject: Subject) {
         self.subjects.push(subject);
     }
+
+    pub fn get_subject(&self, id: &str) -> Option<&Subject> {
+        self.subjects.iter().find(|subject| subject.id() == id)
+    }
     pub fn write_pmetrics(&self, file: &std::fs::File) {
         let mut writer = WriterBuilder::new().has_headers(true).from_writer(file);
 

--- a/src/simulator/equation/sde/mod.rs
+++ b/src/simulator/equation/sde/mod.rs
@@ -9,7 +9,7 @@ use rayon::prelude::*;
 
 use cached::proc_macro::cached;
 use cached::UnboundCache;
-const STEPS: usize = 10;
+const STEPS: usize = 100;
 
 use crate::{
     data::{Covariates, Infusion},
@@ -50,8 +50,10 @@ pub(crate) fn simulate_sde_event(
         x,
         cov.clone(),
         rateiv,
+        1e-4,
+        1e-4,
     );
-    let solution = sde.solve(ti, tf, STEPS);
+    let (_time, solution) = sde.solve(ti, tf);
     solution.last().unwrap().clone()
 }
 

--- a/src/simulator/equation/sde/mod.rs
+++ b/src/simulator/equation/sde/mod.rs
@@ -50,8 +50,8 @@ pub(crate) fn simulate_sde_event(
         x,
         cov.clone(),
         rateiv,
-        1e-4,
-        1e-4,
+        1e-3,
+        1e-3,
     );
     let (_time, solution) = sde.solve(ti, tf);
     solution.last().unwrap().clone()


### PR DESCRIPTION
This pull request introduces several new features and a new `examples/sde.rs` to compare results between ODEs and SDES. It also adds adaptive step size to the SDE solver.

### Adaptive Step Size Control:
* Enhanced the `EM` struct in `src/simulator/equation/sde/em.rs` to include parameters for relative tolerance (`rtol`), absolute tolerance (`atol`), maximum step size (`max_step`), and minimum step size (`min_step`). [[1]](diffhunk://#diff-c484c92c8d8b11878978204296f6f8f281fc500a9cf9d40eeba598ac9eb742d1R17-R20) [[2]](diffhunk://#diff-c484c92c8d8b11878978204296f6f8f281fc500a9cf9d40eeba598ac9eb742d1R32-R33) [[3]](diffhunk://#diff-c484c92c8d8b11878978204296f6f8f281fc500a9cf9d40eeba598ac9eb742d1R42-R123)
* Implemented adaptive step size control in the `solve` method of the `EM` struct, improving the accuracy and efficiency of the Euler-Maruyama method.

### Data Struct Enhancement:
* Added a new method `get_subject` to the `Data` struct in `src/data/structs.rs` to retrieve a subject by its ID.

### Simulation Improvements:
* Increased the number of steps in the SDE simulation from 10 to 100 for better resolution.
* Updated the `simulate_sde_event` function to use the new adaptive step size control in the SDE solver.