### PR TITLE
ci: Benchmark with self-hosted runners

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -2,14 +2,14 @@ name: Benchmark (main)
 
 on:
   push:
-    branches: main
+    branches: [main]
 
 jobs:
   benchmark_base_branch:
     name: Continuous Benchmarking with Bencher
     permissions:
       checks: write
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: bencherdev/bencher@main
@@ -19,7 +19,7 @@ jobs:
           --project pharmsol \
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
           --branch main \
-          --testbed ubuntu-latest \
+          --testbed ${{ runner.name }} \
           --threshold-measure latency \
           --threshold-test t_test \
           --threshold-max-sample-size 64 \

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: bencherdev/bencher@main
@@ -25,7 +25,7 @@ jobs:
           --start-point-hash '${{ github.event.pull_request.base.sha }}' \
           --start-point-clone-thresholds \
           --start-point-reset \
-          --testbed ubuntu-latest \
+          --testbed ${{ runner.name }} \
           --err \
           --adapter rust_criterion \
           --github-actions '${{ secrets.GITHUB_TOKEN }}' \


### PR DESCRIPTION
Updates benchmark CI to use self-hosted runners. Testbed should be automatically populated with the name of the runner for more fair comparisons.