### PR TITLE
ci: Update CI for building and testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,36 +16,25 @@ env:
 
 jobs:
   
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Setup cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
-  
-  os-check:
+  test:
     runs-on: '${{ matrix.os }}'
     name: '${{ matrix.os }} / stable'
     strategy:
       fail-fast: false
       matrix:
         os:
+          - ubuntu-latest
           - macos-latest
           - windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      
       - name: Setup cache
         uses: actions/cache@v4
         with:
@@ -54,7 +43,30 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Build
+      
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      
+      - name: Build (no features)
+        run: cargo build --verbose --no-default-features
+      
+      - name: Build (default features)
         run: cargo build --verbose
-      - name: Run tests
+      
+      - name: Build (all features)
+        run: cargo build --verbose --all-features
+      
+      - name: Run tests (no features)
+        run: cargo test --verbose --no-default-features
+      
+      - name: Run tests (default features)
         run: cargo test --verbose
+      
+      - name: Run tests (all features)
+        run: cargo test --verbose --all-features
+      
+      - name: Run doc tests
+        run: cargo test --doc --all-features


### PR DESCRIPTION
Replaces the 'build' and 'os-check' jobs with a unified 'test' job that runs on multiple OSes. Adds Rust toolchain installation, formatting checks, clippy lints, and builds/tests with no, default, and all features, including doc tests. Improves CI coverage and code quality enforcement.