### PR TITLE
feat: Support fixed and variable scalars for error models

### DIFF
--- a/src/data/error_model.rs
+++ b/src/data/error_model.rs
@@ -6,17 +6,17 @@ use thiserror::Error;
 
 /// Parameter that can be either fixed or variable for estimation
 ///
-/// This enum allows specifying whether a scalar parameter (like lambda or gamma)
+/// This enum allows specifying whether a factor parameter (like lambda or gamma)
 /// should be fixed at a specific value or allowed to vary during estimation.
 #[derive(Debug, Clone, Serialize, Deserialize, Copy, PartialEq)]
-pub enum Scalar {
+pub enum Factor {
     /// Parameter can be estimated/varied during optimization
     Variable(f64),
     /// Parameter is fixed at this value and won't be estimated
     Fixed(f64),
 }
 
-impl Scalar {
+impl Factor {
     /// Get the current value of the parameter
     pub fn value(&self) -> f64 {
         match self {
@@ -56,11 +56,11 @@ impl Scalar {
         }
     }
 
-    /// Replace the current scalar with a new scalar value
-    pub fn set_scalar(&mut self, scalar: &Scalar) {
-        match scalar {
-            Scalar::Variable(val) => *self = Self::Variable(*val),
-            Scalar::Fixed(val) => *self = Self::Fixed(*val),
+    /// Replace the current factor with a new factor value
+    pub fn set_factor(&mut self, factor: &Factor) {
+        match factor {
+            Factor::Variable(val) => *self = Self::Variable(*val),
+            Factor::Fixed(val) => *self = Self::Fixed(*val),
         }
     }
 }
@@ -268,7 +268,7 @@ impl ErrorModels {
         self.models[outeq].errorpoly()
     }
 
-    /// Returns the scalar value associated with the specified output equation.
+    /// Returns the factor value associated with the specified output equation.
     ///
     /// # Arguments
     ///
@@ -276,15 +276,15 @@ impl ErrorModels {
     ///
     /// # Returns
     ///
-    /// The scalar value for the given output equation.
-    pub fn scalar(&self, outeq: usize) -> Result<f64, ErrorModelError> {
+    /// The factor value for the given output equation.
+    pub fn factor(&self, outeq: usize) -> Result<f64, ErrorModelError> {
         if outeq >= self.models.len() {
             return Err(ErrorModelError::InvalidOutputEquation(outeq));
         }
         if self.models[outeq] == ErrorModel::None {
             return Err(ErrorModelError::NoneErrorModel(outeq));
         }
-        Ok(self.models[outeq].scalar()?)
+        Ok(self.models[outeq].factor()?)
     }
 
     /// Sets the error polynomial for the specified output equation.
@@ -304,24 +304,24 @@ impl ErrorModels {
         Ok(())
     }
 
-    /// Sets the scalar value for the specified output equation.
+    /// Sets the factor value for the specified output equation.
     ///
     /// # Arguments
     ///
     /// * `outeq` - The index of the output equation.
-    /// * `scalar` - The new scalar value to set.
-    pub fn set_scalar(&mut self, outeq: usize, scalar: f64) -> Result<(), ErrorModelError> {
+    /// * `factor` - The new factor value to set.
+    pub fn set_factor(&mut self, outeq: usize, factor: f64) -> Result<(), ErrorModelError> {
         if outeq >= self.models.len() {
             return Err(ErrorModelError::InvalidOutputEquation(outeq));
         }
         if self.models[outeq] == ErrorModel::None {
             return Err(ErrorModelError::NoneErrorModel(outeq));
         }
-        self.models[outeq].set_scalar(scalar);
+        self.models[outeq].set_factor(factor);
         Ok(())
     }
 
-    /// Gets the scalar parameter (including fixed/variable state) for the specified output equation.
+    /// Gets the factor parameter (including fixed/variable state) for the specified output equation.
     ///
     /// # Arguments
     ///
@@ -329,35 +329,35 @@ impl ErrorModels {
     ///
     /// # Returns
     ///
-    /// The [`Scalar`] for the given output equation.
-    pub fn scalar_param(&self, outeq: usize) -> Result<Scalar, ErrorModelError> {
+    /// The [`Factor`] for the given output equation.
+    pub fn factor_param(&self, outeq: usize) -> Result<Factor, ErrorModelError> {
         if outeq >= self.models.len() {
             return Err(ErrorModelError::InvalidOutputEquation(outeq));
         }
         if self.models[outeq] == ErrorModel::None {
             return Err(ErrorModelError::NoneErrorModel(outeq));
         }
-        self.models[outeq].scalar_param()
+        self.models[outeq].factor_param()
     }
 
-    /// Sets the scalar parameter (including fixed/variable state) for the specified output equation.
+    /// Sets the factor parameter (including fixed/variable state) for the specified output equation.
     ///
     /// # Arguments
     ///
     /// * `outeq` - The index of the output equation.
-    /// * `param` - The new [`Scalar`] to set.
-    pub fn set_scalar_param(&mut self, outeq: usize, param: Scalar) -> Result<(), ErrorModelError> {
+    /// * `param` - The new [`Factor`] to set.
+    pub fn set_factor_param(&mut self, outeq: usize, param: Factor) -> Result<(), ErrorModelError> {
         if outeq >= self.models.len() {
             return Err(ErrorModelError::InvalidOutputEquation(outeq));
         }
         if self.models[outeq] == ErrorModel::None {
             return Err(ErrorModelError::NoneErrorModel(outeq));
         }
-        self.models[outeq].set_scalar_param(param);
+        self.models[outeq].set_factor_param(param);
         Ok(())
     }
 
-    /// Checks if the scalar parameter is fixed for the specified output equation.
+    /// Checks if the factor parameter is fixed for the specified output equation.
     ///
     /// # Arguments
     ///
@@ -365,46 +365,46 @@ impl ErrorModels {
     ///
     /// # Returns
     ///
-    /// `true` if the scalar parameter is fixed, `false` if it's variable.
-    pub fn is_scalar_fixed(&self, outeq: usize) -> Result<bool, ErrorModelError> {
+    /// `true` if the factor parameter is fixed, `false` if it's variable.
+    pub fn is_factor_fixed(&self, outeq: usize) -> Result<bool, ErrorModelError> {
         if outeq >= self.models.len() {
             return Err(ErrorModelError::InvalidOutputEquation(outeq));
         }
         if self.models[outeq] == ErrorModel::None {
             return Err(ErrorModelError::NoneErrorModel(outeq));
         }
-        self.models[outeq].is_scalar_fixed()
+        self.models[outeq].is_factor_fixed()
     }
 
-    /// Makes the scalar parameter fixed at its current value for the specified output equation.
+    /// Makes the factor parameter fixed at its current value for the specified output equation.
     ///
     /// # Arguments
     ///
     /// * `outeq` - The index of the output equation.
-    pub fn fix_scalar(&mut self, outeq: usize) -> Result<(), ErrorModelError> {
+    pub fn fix_factor(&mut self, outeq: usize) -> Result<(), ErrorModelError> {
         if outeq >= self.models.len() {
             return Err(ErrorModelError::InvalidOutputEquation(outeq));
         }
         if self.models[outeq] == ErrorModel::None {
             return Err(ErrorModelError::NoneErrorModel(outeq));
         }
-        self.models[outeq].fix_scalar();
+        self.models[outeq].fix_factor();
         Ok(())
     }
 
-    /// Makes the scalar parameter variable at its current value for the specified output equation.
+    /// Makes the factor parameter variable at its current value for the specified output equation.
     ///
     /// # Arguments
     ///
     /// * `outeq` - The index of the output equation.
-    pub fn unfix_scalar(&mut self, outeq: usize) -> Result<(), ErrorModelError> {
+    pub fn unfix_factor(&mut self, outeq: usize) -> Result<(), ErrorModelError> {
         if outeq >= self.models.len() {
             return Err(ErrorModelError::InvalidOutputEquation(outeq));
         }
         if self.models[outeq] == ErrorModel::None {
             return Err(ErrorModelError::NoneErrorModel(outeq));
         }
-        self.models[outeq].unfix_scalar();
+        self.models[outeq].unfix_factor();
         Ok(())
     }
 
@@ -535,7 +535,7 @@ pub enum ErrorModel {
     /// * `poly` - Error polynomial coefficients (c0, c1, c2, c3)
     Additive {
         /// Lambda parameter for scaling errors (can be fixed or variable)
-        lambda: Scalar,
+        lambda: Factor,
         /// Error polynomial coefficients (c0, c1, c2, c3)
         poly: ErrorPoly,
         /// Optional: lloq (Lower Limit of Quantification) of the analytical method
@@ -549,7 +549,7 @@ pub enum ErrorModel {
     /// * `poly` - Error polynomial coefficients (c0, c1, c2, c3)
     Proportional {
         /// Gamma parameter for scaling errors (can be fixed or variable)
-        gamma: Scalar,
+        gamma: Factor,
         /// Error polynomial coefficients (c0, c1, c2, c3)
         poly: ErrorPoly,
         /// Optional: lloq (Lower Limit of Quantification) of the analytical method
@@ -573,7 +573,7 @@ impl ErrorModel {
     /// A new additive error model
     pub fn additive(poly: ErrorPoly, lambda: f64, lloq: Option<f64>) -> Self {
         Self::Additive {
-            lambda: Scalar::Variable(lambda),
+            lambda: Factor::Variable(lambda),
             poly,
             lloq,
         }
@@ -592,24 +592,24 @@ impl ErrorModel {
     /// A new additive error model with fixed lambda
     pub fn additive_fixed(poly: ErrorPoly, lambda: f64, lloq: Option<f64>) -> Self {
         Self::Additive {
-            lambda: Scalar::Fixed(lambda),
+            lambda: Factor::Fixed(lambda),
             poly,
             lloq,
         }
     }
 
-    /// Create a new additive error model with a specified Scalar for lambda
+    /// Create a new additive error model with a specified Factor for lambda
     ///
     /// # Arguments
     ///
     /// * `poly` - Error polynomial coefficients (c0, c1, c2, c3)
-    /// * `lambda` - Lambda parameter (can be Variable or Fixed) using [Scalar]
+    /// * `lambda` - Lambda parameter (can be Variable or Fixed) using [Factor]
     /// * `lloq` - Optional lower limit of quantification
     ///
     /// # Returns
     ///
     /// A new additive error model
-    pub fn additive_with_param(poly: ErrorPoly, lambda: Scalar, lloq: Option<f64>) -> Self {
+    pub fn additive_with_param(poly: ErrorPoly, lambda: Factor, lloq: Option<f64>) -> Self {
         Self::Additive { lambda, poly, lloq }
     }
 
@@ -639,7 +639,7 @@ impl ErrorModel {
     /// A new proportional error model
     pub fn proportional(poly: ErrorPoly, gamma: f64, lloq: Option<f64>) -> Self {
         Self::Proportional {
-            gamma: Scalar::Variable(gamma),
+            gamma: Factor::Variable(gamma),
             poly,
             lloq,
         }
@@ -658,24 +658,24 @@ impl ErrorModel {
     /// A new proportional error model with fixed gamma
     pub fn proportional_fixed(poly: ErrorPoly, gamma: f64, lloq: Option<f64>) -> Self {
         Self::Proportional {
-            gamma: Scalar::Fixed(gamma),
+            gamma: Factor::Fixed(gamma),
             poly,
             lloq,
         }
     }
 
-    /// Create a new proportional error model with a specified Scalar for gamma
+    /// Create a new proportional error model with a specified Factor for gamma
     ///
     /// # Arguments
     ///
     /// * `poly` - Error polynomial coefficients (c0, c1, c2, c3)
-    /// * `gamma` - Gamma parameter (can be Variable or Fixed) using [Scalar]
+    /// * `gamma` - Gamma parameter (can be Variable or Fixed) using [Factor]
     /// * `lloq` - Optional lower limit of quantification
     ///
     /// # Returns
     ///
     /// A new proportional error model
-    pub fn proportional_with_param(poly: ErrorPoly, gamma: Scalar, lloq: Option<f64>) -> Self {
+    pub fn proportional_with_param(poly: ErrorPoly, gamma: Factor, lloq: Option<f64>) -> Self {
         Self::Proportional { gamma, poly, lloq }
     }
 
@@ -710,7 +710,7 @@ impl ErrorModel {
     }
 
     /// Get the scaling parameter value
-    pub fn scalar(&self) -> Result<f64, ErrorModelError> {
+    pub fn factor(&self) -> Result<f64, ErrorModelError> {
         match self {
             Self::Additive { lambda, .. } => Ok(lambda.value()),
             Self::Proportional { gamma, .. } => Ok(gamma.value()),
@@ -719,16 +719,16 @@ impl ErrorModel {
     }
 
     /// Set the scaling parameter value (preserves fixed/variable state)
-    pub fn set_scalar(&mut self, scalar: f64) {
+    pub fn set_factor(&mut self, factor: f64) {
         match self {
-            Self::Additive { lambda, .. } => lambda.set_value(scalar),
-            Self::Proportional { gamma, .. } => gamma.set_value(scalar),
+            Self::Additive { lambda, .. } => lambda.set_value(factor),
+            Self::Proportional { gamma, .. } => gamma.set_value(factor),
             Self::None => {}
         }
     }
 
     /// Get the scaling parameter (including its fixed/variable state)
-    pub fn scalar_param(&self) -> Result<Scalar, ErrorModelError> {
+    pub fn factor_param(&self) -> Result<Factor, ErrorModelError> {
         match self {
             Self::Additive { lambda, .. } => Ok(*lambda),
             Self::Proportional { gamma, .. } => Ok(*gamma),
@@ -737,7 +737,7 @@ impl ErrorModel {
     }
 
     /// Set the scaling parameter (including its fixed/variable state)
-    pub fn set_scalar_param(&mut self, param: Scalar) {
+    pub fn set_factor_param(&mut self, param: Factor) {
         match self {
             Self::Additive { lambda, .. } => *lambda = param,
             Self::Proportional { gamma, .. } => *gamma = param,
@@ -746,7 +746,7 @@ impl ErrorModel {
     }
 
     /// Check if the scaling parameter is fixed
-    pub fn is_scalar_fixed(&self) -> Result<bool, ErrorModelError> {
+    pub fn is_factor_fixed(&self) -> Result<bool, ErrorModelError> {
         match self {
             Self::Additive { lambda, .. } => Ok(lambda.is_fixed()),
             Self::Proportional { gamma, .. } => Ok(gamma.is_fixed()),
@@ -755,7 +755,7 @@ impl ErrorModel {
     }
 
     /// Make the scaling parameter fixed at its current value
-    pub fn fix_scalar(&mut self) {
+    pub fn fix_factor(&mut self) {
         match self {
             Self::Additive { lambda, .. } => lambda.make_fixed(),
             Self::Proportional { gamma, .. } => gamma.make_fixed(),
@@ -764,7 +764,7 @@ impl ErrorModel {
     }
 
     /// Make the scaling parameter variable at its current value
-    pub fn unfix_scalar(&mut self) {
+    pub fn unfix_factor(&mut self) {
         match self {
             Self::Additive { lambda, .. } => lambda.make_variable(),
             Self::Proportional { gamma, .. } => gamma.make_variable(),
@@ -937,11 +937,11 @@ mod tests {
     }
 
     #[test]
-    fn test_set_scalar() {
+    fn test_set_factor() {
         let mut model = ErrorModel::additive(ErrorPoly::new(1.0, 2.0, 3.0, 4.0), 5.0, None);
-        assert_eq!(model.scalar().unwrap(), 5.0);
-        model.set_scalar(10.0);
-        assert_eq!(model.scalar().unwrap(), 10.0);
+        assert_eq!(model.factor().unwrap(), 5.0);
+        model.set_factor(10.0);
+        assert_eq!(model.factor().unwrap(), 10.0);
     }
 
     #[test]
@@ -1001,19 +1001,19 @@ mod tests {
     }
 
     #[test]
-    fn test_error_models_scalar() {
+    fn test_error_models_factor() {
         let model = ErrorModel::additive(ErrorPoly::new(1.0, 0.0, 0.0, 0.0), 5.0, None);
         let models = ErrorModels::new().add(0, model).unwrap();
 
-        assert_eq!(models.scalar(0).unwrap(), 5.0);
+        assert_eq!(models.factor(0).unwrap(), 5.0);
     }
 
     #[test]
-    fn test_error_models_scalar_invalid_outeq() {
+    fn test_error_models_factor_invalid_outeq() {
         let model = ErrorModel::additive(ErrorPoly::new(1.0, 0.0, 0.0, 0.0), 5.0, None);
         let models = ErrorModels::new().add(0, model).unwrap();
 
-        let result = models.scalar(1);
+        let result = models.factor(1);
         assert!(result.is_err());
         match result {
             Err(ErrorModelError::InvalidOutputEquation(outeq)) => assert_eq!(outeq, 1),
@@ -1022,21 +1022,21 @@ mod tests {
     }
 
     #[test]
-    fn test_error_models_set_scalar() {
+    fn test_error_models_set_factor() {
         let model = ErrorModel::additive(ErrorPoly::new(1.0, 0.0, 0.0, 0.0), 5.0, None);
         let mut models = ErrorModels::new().add(0, model).unwrap();
 
-        assert_eq!(models.scalar(0).unwrap(), 5.0);
-        models.set_scalar(0, 10.0).unwrap();
-        assert_eq!(models.scalar(0).unwrap(), 10.0);
+        assert_eq!(models.factor(0).unwrap(), 5.0);
+        models.set_factor(0, 10.0).unwrap();
+        assert_eq!(models.factor(0).unwrap(), 10.0);
     }
 
     #[test]
-    fn test_error_models_set_scalar_invalid_outeq() {
+    fn test_error_models_set_factor_invalid_outeq() {
         let model = ErrorModel::additive(ErrorPoly::new(1.0, 0.0, 0.0, 0.0), 5.0, None);
         let mut models = ErrorModels::new().add(0, model).unwrap();
 
-        let result = models.set_scalar(1, 10.0);
+        let result = models.set_factor(1, 10.0);
         assert!(result.is_err());
         match result {
             Err(ErrorModelError::InvalidOutputEquation(outeq)) => assert_eq!(outeq, 1),
@@ -1257,9 +1257,9 @@ mod tests {
 
         assert_eq!(models.len(), 2);
 
-        // Test scalar retrieval for different outeqs
-        assert_eq!(models.scalar(0).unwrap(), 0.5);
-        assert_eq!(models.scalar(1).unwrap(), 0.1);
+        // Test factor retrieval for different outeqs
+        assert_eq!(models.factor(0).unwrap(), 0.5);
+        assert_eq!(models.factor(1).unwrap(), 0.1);
 
         // Test polynomial retrieval for different outeqs
         assert_eq!(
@@ -1298,77 +1298,77 @@ mod tests {
     }
 
     #[test]
-    fn test_scalar_param_new_constructors() {
+    fn test_factor_param_new_constructors() {
         // Test variable constructors (default behavior)
         let additive = ErrorModel::additive(ErrorPoly::new(1.0, 0.0, 0.0, 0.0), 5.0, None);
-        assert_eq!(additive.scalar().unwrap(), 5.0);
-        assert!(!additive.is_scalar_fixed().unwrap());
+        assert_eq!(additive.factor().unwrap(), 5.0);
+        assert!(!additive.is_factor_fixed().unwrap());
 
         let proportional = ErrorModel::proportional(ErrorPoly::new(1.0, 0.0, 0.0, 0.0), 2.0, None);
-        assert_eq!(proportional.scalar().unwrap(), 2.0);
-        assert!(!proportional.is_scalar_fixed().unwrap());
+        assert_eq!(proportional.factor().unwrap(), 2.0);
+        assert!(!proportional.is_factor_fixed().unwrap());
 
         // Test fixed constructors
         let additive_fixed =
             ErrorModel::additive_fixed(ErrorPoly::new(1.0, 0.0, 0.0, 0.0), 5.0, None);
-        assert_eq!(additive_fixed.scalar().unwrap(), 5.0);
-        assert!(additive_fixed.is_scalar_fixed().unwrap());
+        assert_eq!(additive_fixed.factor().unwrap(), 5.0);
+        assert!(additive_fixed.is_factor_fixed().unwrap());
 
         let proportional_fixed =
             ErrorModel::proportional_fixed(ErrorPoly::new(1.0, 0.0, 0.0, 0.0), 2.0, None);
-        assert_eq!(proportional_fixed.scalar().unwrap(), 2.0);
-        assert!(proportional_fixed.is_scalar_fixed().unwrap());
+        assert_eq!(proportional_fixed.factor().unwrap(), 2.0);
+        assert!(proportional_fixed.is_factor_fixed().unwrap());
 
-        // Test Scalar constructors
+        // Test Factor constructors
         let additive_with_param = ErrorModel::additive_with_param(
             ErrorPoly::new(1.0, 0.0, 0.0, 0.0),
-            Scalar::Fixed(5.0),
+            Factor::Fixed(5.0),
             None,
         );
-        assert_eq!(additive_with_param.scalar().unwrap(), 5.0);
-        assert!(additive_with_param.is_scalar_fixed().unwrap());
+        assert_eq!(additive_with_param.factor().unwrap(), 5.0);
+        assert!(additive_with_param.is_factor_fixed().unwrap());
 
         let proportional_with_param = ErrorModel::proportional_with_param(
             ErrorPoly::new(1.0, 0.0, 0.0, 0.0),
-            Scalar::Variable(2.0),
+            Factor::Variable(2.0),
             None,
         );
-        assert_eq!(proportional_with_param.scalar().unwrap(), 2.0);
-        assert!(!proportional_with_param.is_scalar_fixed().unwrap());
+        assert_eq!(proportional_with_param.factor().unwrap(), 2.0);
+        assert!(!proportional_with_param.is_factor_fixed().unwrap());
     }
 
     #[test]
-    fn test_scalar_param_methods() {
+    fn test_factor_param_methods() {
         let mut model = ErrorModel::additive(ErrorPoly::new(1.0, 0.0, 0.0, 0.0), 5.0, None);
 
         // Test initial state
-        assert_eq!(model.scalar().unwrap(), 5.0);
-        assert!(!model.is_scalar_fixed().unwrap());
+        assert_eq!(model.factor().unwrap(), 5.0);
+        assert!(!model.is_factor_fixed().unwrap());
 
         // Test fixing parameter
-        model.fix_scalar();
-        assert_eq!(model.scalar().unwrap(), 5.0);
-        assert!(model.is_scalar_fixed().unwrap());
+        model.fix_factor();
+        assert_eq!(model.factor().unwrap(), 5.0);
+        assert!(model.is_factor_fixed().unwrap());
 
         // Test unfixing parameter
-        model.unfix_scalar();
-        assert_eq!(model.scalar().unwrap(), 5.0);
-        assert!(!model.is_scalar_fixed().unwrap());
+        model.unfix_factor();
+        assert_eq!(model.factor().unwrap(), 5.0);
+        assert!(!model.is_factor_fixed().unwrap());
 
-        // Test setting scalar param directly
-        model.set_scalar_param(Scalar::Fixed(10.0));
-        assert_eq!(model.scalar().unwrap(), 10.0);
-        assert!(model.is_scalar_fixed().unwrap());
+        // Test setting factor param directly
+        model.set_factor_param(Factor::Fixed(10.0));
+        assert_eq!(model.factor().unwrap(), 10.0);
+        assert!(model.is_factor_fixed().unwrap());
 
-        // Test getting scalar param
-        let param = model.scalar_param().unwrap();
+        // Test getting factor param
+        let param = model.factor_param().unwrap();
         assert_eq!(param.value(), 10.0);
         assert!(param.is_fixed());
     }
 
     #[test]
-    fn test_scalar_param_functionality() {
-        let mut param = Scalar::Variable(5.0);
+    fn test_factor_param_functionality() {
+        let mut param = Factor::Variable(5.0);
 
         // Test basic functionality
         assert_eq!(param.value(), 5.0);
@@ -1394,7 +1394,7 @@ mod tests {
     }
 
     #[test]
-    fn test_error_models_scalar_param_methods() {
+    fn test_error_models_factor_param_methods() {
         let additive_model =
             ErrorModel::additive_fixed(ErrorPoly::new(1.0, 0.0, 0.0, 0.0), 5.0, None);
         let proportional_model =
@@ -1406,30 +1406,30 @@ mod tests {
             .add(1, proportional_model)
             .unwrap();
 
-        // Test scalar param retrieval
-        let param0 = models.scalar_param(0).unwrap();
+        // Test factor param retrieval
+        let param0 = models.factor_param(0).unwrap();
         assert_eq!(param0.value(), 5.0);
         assert!(param0.is_fixed());
 
-        let param1 = models.scalar_param(1).unwrap();
+        let param1 = models.factor_param(1).unwrap();
         assert_eq!(param1.value(), 2.0);
         assert!(param1.is_variable());
 
-        // Test is_scalar_fixed
-        assert!(models.is_scalar_fixed(0).unwrap());
-        assert!(!models.is_scalar_fixed(1).unwrap());
+        // Test is_factor_fixed
+        assert!(models.is_factor_fixed(0).unwrap());
+        assert!(!models.is_factor_fixed(1).unwrap());
 
         // Test fixing/unfixing
-        models.fix_scalar(1).unwrap();
-        assert!(models.is_scalar_fixed(1).unwrap());
+        models.fix_factor(1).unwrap();
+        assert!(models.is_factor_fixed(1).unwrap());
 
-        models.unfix_scalar(0).unwrap();
-        assert!(!models.is_scalar_fixed(0).unwrap());
+        models.unfix_factor(0).unwrap();
+        assert!(!models.is_factor_fixed(0).unwrap());
 
-        // Test setting scalar param
-        models.set_scalar_param(0, Scalar::Fixed(10.0)).unwrap();
-        assert_eq!(models.scalar(0).unwrap(), 10.0);
-        assert!(models.is_scalar_fixed(0).unwrap());
+        // Test setting factor param
+        models.set_factor_param(0, Factor::Fixed(10.0)).unwrap();
+        assert_eq!(models.factor(0).unwrap(), 10.0);
+        assert!(models.is_factor_fixed(0).unwrap());
     }
 
     #[test]
@@ -1481,36 +1481,36 @@ mod tests {
             .unwrap();
 
         // Verify initial state - both should be variable
-        assert!(!models.is_scalar_fixed(0).unwrap());
-        assert!(!models.is_scalar_fixed(1).unwrap());
-        assert_eq!(models.scalar(0).unwrap(), 5.0);
-        assert_eq!(models.scalar(1).unwrap(), 2.0);
+        assert!(!models.is_factor_fixed(0).unwrap());
+        assert!(!models.is_factor_fixed(1).unwrap());
+        assert_eq!(models.factor(0).unwrap(), 5.0);
+        assert_eq!(models.factor(1).unwrap(), 2.0);
 
         // First iteration: update values using iter_mut
         for (outeq, model) in models.iter_mut() {
             match outeq {
-                0 => model.set_scalar(10.0), // Update additive lambda from 5.0 to 10.0
-                1 => model.set_scalar(4.0),  // Update proportional gamma from 2.0 to 4.0
+                0 => model.set_factor(10.0), // Update additive lambda from 5.0 to 10.0
+                1 => model.set_factor(4.0),  // Update proportional gamma from 2.0 to 4.0
                 _ => {}
             }
         }
 
         // Verify values were updated
-        assert_eq!(models.scalar(0).unwrap(), 10.0);
-        assert_eq!(models.scalar(1).unwrap(), 4.0);
-        assert!(!models.is_scalar_fixed(0).unwrap()); // Still variable
-        assert!(!models.is_scalar_fixed(1).unwrap()); // Still variable
+        assert_eq!(models.factor(0).unwrap(), 10.0);
+        assert_eq!(models.factor(1).unwrap(), 4.0);
+        assert!(!models.is_factor_fixed(0).unwrap()); // Still variable
+        assert!(!models.is_factor_fixed(1).unwrap()); // Still variable
 
         // Second iteration: fix all parameters using iter_mut
         for (_outeq, model) in models.iter_mut() {
-            model.fix_scalar();
+            model.fix_factor();
         }
 
         // Verify all parameters are now fixed
-        assert!(models.is_scalar_fixed(0).unwrap());
-        assert!(models.is_scalar_fixed(1).unwrap());
-        assert_eq!(models.scalar(0).unwrap(), 10.0); // Values should remain the same
-        assert_eq!(models.scalar(1).unwrap(), 4.0);
+        assert!(models.is_factor_fixed(0).unwrap());
+        assert!(models.is_factor_fixed(1).unwrap());
+        assert_eq!(models.factor(0).unwrap(), 10.0); // Values should remain the same
+        assert_eq!(models.factor(1).unwrap(), 4.0);
 
         // Test read-only iteration with iter()
         let mut count = 0;
@@ -1518,12 +1518,12 @@ mod tests {
             count += 1;
             match outeq {
                 0 => {
-                    assert!(model.is_scalar_fixed().unwrap());
-                    assert_eq!(model.scalar().unwrap(), 10.0);
+                    assert!(model.is_factor_fixed().unwrap());
+                    assert_eq!(model.factor().unwrap(), 10.0);
                 }
                 1 => {
-                    assert!(model.is_scalar_fixed().unwrap());
-                    assert_eq!(model.scalar().unwrap(), 4.0);
+                    assert!(model.is_factor_fixed().unwrap());
+                    assert_eq!(model.factor().unwrap(), 4.0);
                 }
                 _ => panic!("Unexpected outeq: {}", outeq),
             }
@@ -1540,9 +1540,9 @@ mod tests {
 
         assert_eq!(*outeq0, 0);
         assert_eq!(*outeq1, 1);
-        assert!(model0.is_scalar_fixed().unwrap());
-        assert!(model1.is_scalar_fixed().unwrap());
-        assert_eq!(model0.scalar().unwrap(), 10.0);
-        assert_eq!(model1.scalar().unwrap(), 4.0);
+        assert!(model0.is_factor_fixed().unwrap());
+        assert!(model1.is_factor_fixed().unwrap());
+        assert_eq!(model0.factor().unwrap(), 10.0);
+        assert_eq!(model1.factor().unwrap(), 4.0);
     }
 }


### PR DESCRIPTION
This will allow PMcore to selectively optimize the given error models.

The API is compatible with the current implementation, but provides additional creator functions for interacting with the new Scalar structure.

We may need to rethink the name for the structure, since its a fairly common structure name in linear algebra.