### PR TITLE
fix: Handle NA in Pmetrics files

### DIFF
--- a/src/data/parse_pmetrics.rs
+++ b/src/data/parse_pmetrics.rs
@@ -409,7 +409,7 @@ where
     T::Err: std::fmt::Display,
 {
     let s: String = Deserialize::deserialize(deserializer)?;
-    if s.is_empty() || s == "." {
+    if s.is_empty() || s == "." || s == "NA" {
         Ok(None)
     } else {
         T::from_str(&s).map(Some).map_err(serde::de::Error::custom)


### PR DESCRIPTION
When Pmetrics datafiles are written using e.g. `readr::write_csv`, missing values are written as "NA". This PR adds a simple check which parses `NA` correctly as `None`.