### PR TITLE
chore: Bump nalgebra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ cached = { version = "0.56.0" }
 csv = "1.3.0"
 diffsol = "0.6.6"
 libloading = { version = "0.8.6", optional = true, features = [] }
-nalgebra = "0.33.0"
+nalgebra = "0.34.1"
 ndarray = { version = "0.16.1", features = ["rayon"] }
 rand = "0.9.0"
 rand_distr = "0.5.0"


### PR DESCRIPTION
The previous version was incompatible with other crates, and caused a compilation error.