### PR TITLE
chore: Downgrade ndarray version from 0.17.1 to 0.16.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ csv = "1.3.0"
 diffsol = "=0.7.0"
 libloading = { version = "0.8.6", optional = true, features = [] }
 nalgebra = "0.34.1"
-ndarray = { version = "0.17.1", features = ["rayon"] }
+ndarray = { version = "0.16.1", features = ["rayon"] }
 rand = "0.9.0"
 rand_distr = "0.5.0"
 rayon = "1.10.0"


### PR DESCRIPTION
We have to use 0.16.1 as faer-ext still does not support ndarray 0.16