### PR TITLE
feat: Remove API for regular likelihood

### DIFF
--- a/examples/one_compartment.rs
+++ b/examples/one_compartment.rs
@@ -67,28 +67,28 @@ fn main() -> Result<(), pharmsol::PharmsolError> {
     let ke = 1.022; // Elimination rate constant
     let v = 194.0; // Volume of distribution
 
-    // Compute likelihoods and predictions for both models
-    let analytical_likelihoods = an.estimate_likelihood(&subject, &vec![ke, v], &ems, false)?;
+    // Compute log-likelihoods and predictions for both models
+    let analytical_log_lik = an.estimate_log_likelihood(&subject, &vec![ke, v], &ems, false)?;
 
     let analytical_predictions = an.estimate_predictions(&subject, &vec![ke, v])?;
 
-    let ode_likelihoods = ode.estimate_likelihood(&subject, &vec![ke, v], &ems, false)?;
+    let ode_log_lik = ode.estimate_log_likelihood(&subject, &vec![ke, v], &ems, false)?;
 
     let ode_predictions = ode.estimate_predictions(&subject, &vec![ke, v])?;
 
     // Print comparison table
-    println!("\n┌───────────┬─────────────────┬─────────────────┬─────────────────────┐");
-    println!("│           │   Analytical    │       ODE       │     Difference      │");
-    println!("├───────────┼─────────────────┼─────────────────┼─────────────────────┤");
+    println!("\n┌─────────────────┬─────────────────┬─────────────────┬─────────────────────┐");
+    println!("│                 │   Analytical    │       ODE       │     Difference      │");
+    println!("├─────────────────┼─────────────────┼─────────────────┼─────────────────────┤");
     println!(
-        "│ Likelihood│ {:>15.6} │ {:>15.6} │ {:>19.2e} │",
-        analytical_likelihoods,
-        ode_likelihoods,
-        analytical_likelihoods - ode_likelihoods
+        "│ Log-Likelihood  │ {:>15.6} │ {:>15.6} │ {:>19.2e} │",
+        analytical_log_lik,
+        ode_log_lik,
+        analytical_log_lik - ode_log_lik
     );
-    println!("├───────────┼─────────────────┼─────────────────┼─────────────────────┤");
-    println!("│   Time    │   Prediction    │   Prediction    │                     │");
-    println!("├───────────┼─────────────────┼─────────────────┼─────────────────────┤");
+    println!("├─────────────────┼─────────────────┼─────────────────┼─────────────────────┤");
+    println!("│   Time          │   Prediction    │   Prediction    │                     │");
+    println!("├─────────────────┼─────────────────┼─────────────────┼─────────────────────┤");
 
     let times = analytical_predictions.flat_times();
     let analytical_preds = analytical_predictions.flat_predictions();
@@ -101,12 +101,12 @@ fn main() -> Result<(), pharmsol::PharmsolError> {
     {
         let diff = a - b;
         println!(
-            "│ {:>9.2} │ {:>15.9} │ {:>15.9} │ {:>19.2e} │",
+            "│ {:>15.2} │ {:>15.9} │ {:>15.9} │ {:>19.2e} │",
             t, a, b, diff
         );
     }
 
-    println!("└───────────┴─────────────────┴─────────────────┴─────────────────────┘\n");
+    println!("└─────────────────┴─────────────────┴─────────────────┴─────────────────────┘\n");
 
     Ok(())
 }

--- a/examples/pf.rs
+++ b/examples/pf.rs
@@ -37,11 +37,11 @@ fn main() {
         .unwrap();
 
     let ll = sde
-        .estimate_likelihood(&subject, &vec![1.0], &ems, false)
+        .estimate_log_likelihood(&subject, &vec![1.0], &ems, false)
         .unwrap();
 
     dbg!(sde
-        .estimate_likelihood(&subject, &vec![1.0], &ems, false)
+        .estimate_log_likelihood(&subject, &vec![1.0], &ems, false)
         .unwrap());
     println!("{ll:#?}");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub mod prelude {
         pub use crate::simulator::{
             equation,
             equation::Equation,
-            likelihood::{log_psi, psi, PopulationPredictions, Prediction, SubjectPredictions},
+            likelihood::{psi, PopulationPredictions, Prediction, SubjectPredictions},
         };
     }
     pub mod models {

--- a/src/simulator/equation/analytical/mod.rs
+++ b/src/simulator/equation/analytical/mod.rs
@@ -191,7 +191,7 @@ impl EquationPriv for Analytical {
         let pred = y[observation.outeq()];
         let pred = observation.to_prediction(pred, x.as_slice().to_vec());
         if let Some(error_models) = error_models {
-            likelihood.push(pred.likelihood(error_models)?);
+            likelihood.push(pred.log_likelihood(error_models)?);
         }
         output.add_prediction(pred);
         Ok(())
@@ -283,16 +283,6 @@ mod tests {
     }
 }
 impl Equation for Analytical {
-    fn estimate_likelihood(
-        &self,
-        subject: &Subject,
-        support_point: &Vec<f64>,
-        error_models: &ErrorModels,
-        cache: bool,
-    ) -> Result<f64, PharmsolError> {
-        _estimate_likelihood(self, subject, support_point, error_models, cache)
-    }
-
     fn estimate_log_likelihood(
         &self,
         subject: &Subject,
@@ -340,19 +330,4 @@ fn _subject_predictions(
     support_point: &Vec<f64>,
 ) -> Result<SubjectPredictions, PharmsolError> {
     Ok(ode.simulate_subject(subject, support_point, None)?.0)
-}
-
-fn _estimate_likelihood(
-    ode: &Analytical,
-    subject: &Subject,
-    support_point: &Vec<f64>,
-    error_models: &ErrorModels,
-    cache: bool,
-) -> Result<f64, PharmsolError> {
-    let ypred = if cache {
-        _subject_predictions(ode, subject, support_point)
-    } else {
-        _subject_predictions_no_cache(ode, subject, support_point)
-    }?;
-    ypred.likelihood(error_models)
 }

--- a/src/simulator/equation/mod.rs
+++ b/src/simulator/equation/mod.rs
@@ -171,32 +171,10 @@ pub(crate) trait EquationPriv: EquationTypes {
 /// and estimate parameters.
 #[allow(private_bounds)]
 pub trait Equation: EquationPriv + 'static + Clone + Sync {
-    /// Estimate the likelihood of the subject given the support point and error model.
-    ///
-    /// This function calculates how likely the observed data is given the model
-    /// parameters and error model. It may use caching for performance.
-    ///
-    /// # Parameters
-    /// - `subject`: The subject data
-    /// - `support_point`: The parameter values
-    /// - `error_model`: The error model
-    /// - `cache`: Whether to use caching
-    ///
-    /// # Returns
-    /// The likelihood value (product of individual observation likelihoods)
-    fn estimate_likelihood(
-        &self,
-        subject: &Subject,
-        support_point: &Vec<f64>,
-        error_models: &ErrorModels,
-        cache: bool,
-    ) -> Result<f64, PharmsolError>;
-
     /// Estimate the log-likelihood of the subject given the support point and error model.
     ///
     /// This function calculates the log of how likely the observed data is given the model
-    /// parameters and error model. It is numerically more stable than `estimate_likelihood`
-    /// for extreme values or many observations.
+    /// parameters and error model. It is numerically stable for extreme values or many observations.
     ///
     /// # Parameters
     /// - `subject`: The subject data
@@ -282,7 +260,8 @@ pub trait Equation: EquationPriv + 'static + Clone + Sync {
                 )?;
             }
         }
-        let ll = error_models.map(|_| likelihood.iter().product::<f64>());
+        // Return log-likelihood (sum of log-likelihoods) when error_models is provided
+        let ll = error_models.map(|_| likelihood.iter().sum::<f64>());
         Ok((output, ll))
     }
 }

--- a/tests/ode_optimizations.rs
+++ b/tests/ode_optimizations.rs
@@ -881,21 +881,20 @@ fn likelihood_calculation_matches_analytical() {
     let params = vec![0.1, 50.0];
 
     let ll_analytical = analytical
-        .estimate_likelihood(&subject, &params, &error_models, false)
-        .expect("analytical likelihood");
+        .estimate_log_likelihood(&subject, &params, &error_models, false)
+        .expect("analytical log-likelihood");
 
     let ll_ode = ode
-        .estimate_likelihood(&subject, &params, &error_models, false)
-        .expect("ode likelihood");
+        .estimate_log_likelihood(&subject, &params, &error_models, false)
+        .expect("ode log-likelihood");
 
     let ll_diff = (ll_analytical - ll_ode).abs();
-    let ll_rel_diff = ll_diff / ll_analytical.abs().max(1e-10);
-
+    // For log-likelihoods, we compare absolute differences rather than relative
     assert!(
-        ll_rel_diff < 0.01, // Within 1%
-        "Likelihoods should match: analytical={:.6}, ode={:.6}, rel_diff={:.2e}",
+        ll_diff < 0.01, // Within 0.01 log-likelihood units
+        "Log-likelihoods should match: analytical={:.6}, ode={:.6}, diff={:.2e}",
         ll_analytical,
         ll_ode,
-        ll_rel_diff
+        ll_diff
     );
 }


### PR DESCRIPTION
We should only calculate and use the log likelihood for numerical stability