### PR TITLE
feat: Use slices instead of vectors when possible

### DIFF
--- a/benches/analytical_vs_ode.rs
+++ b/benches/analytical_vs_ode.rs
@@ -34,7 +34,7 @@ fn example_subject_oral() -> Subject {
 // One-compartment IV models
 // =============================================================================
 
-fn one_compartment_iv_ode(subject: &Subject, params: &Vec<f64>) {
+fn one_compartment_iv_ode(subject: &Subject, params: &[f64]) {
     let ode = equation::ODE::new(
         |x, p, _t, dx, _b, rateiv, _cov| {
             fetch_params!(p, ke, _v);
@@ -53,7 +53,7 @@ fn one_compartment_iv_ode(subject: &Subject, params: &Vec<f64>) {
     black_box(ode.estimate_predictions(subject, params).unwrap());
 }
 
-fn one_compartment_iv_analytical(subject: &Subject, params: &Vec<f64>) {
+fn one_compartment_iv_analytical(subject: &Subject, params: &[f64]) {
     let analytical = equation::Analytical::new(
         one_compartment,
         |_p, _t, _cov| {},
@@ -74,7 +74,7 @@ fn one_compartment_iv_analytical(subject: &Subject, params: &Vec<f64>) {
 // One-compartment with oral absorption models
 // =============================================================================
 
-fn one_compartment_oral_ode(subject: &Subject, params: &Vec<f64>) {
+fn one_compartment_oral_ode(subject: &Subject, params: &[f64]) {
     let ode = equation::ODE::new(
         |x, p, _t, dx, _b, _rateiv, _cov| {
             fetch_params!(p, ka, ke, _v);
@@ -94,7 +94,7 @@ fn one_compartment_oral_ode(subject: &Subject, params: &Vec<f64>) {
     black_box(ode.estimate_predictions(subject, params).unwrap());
 }
 
-fn one_compartment_oral_analytical(subject: &Subject, params: &Vec<f64>) {
+fn one_compartment_oral_analytical(subject: &Subject, params: &[f64]) {
     let analytical = equation::Analytical::new(
         one_compartment_with_absorption,
         |_p, _t, _cov| {},
@@ -115,7 +115,7 @@ fn one_compartment_oral_analytical(subject: &Subject, params: &Vec<f64>) {
 // Two-compartment IV models
 // =============================================================================
 
-fn two_compartment_iv_ode(subject: &Subject, params: &Vec<f64>) {
+fn two_compartment_iv_ode(subject: &Subject, params: &[f64]) {
     let ode = equation::ODE::new(
         |x, p, _t, dx, _b, rateiv, _cov| {
             fetch_params!(p, ke, k12, k21, _v);
@@ -135,7 +135,7 @@ fn two_compartment_iv_ode(subject: &Subject, params: &Vec<f64>) {
     black_box(ode.estimate_predictions(subject, params).unwrap());
 }
 
-fn two_compartment_iv_analytical(subject: &Subject, params: &Vec<f64>) {
+fn two_compartment_iv_analytical(subject: &Subject, params: &[f64]) {
     let analytical = equation::Analytical::new(
         two_compartments,
         |_p, _t, _cov| {},
@@ -156,7 +156,7 @@ fn two_compartment_iv_analytical(subject: &Subject, params: &Vec<f64>) {
 // Two-compartment with oral absorption models
 // =============================================================================
 
-fn two_compartment_oral_ode(subject: &Subject, params: &Vec<f64>) {
+fn two_compartment_oral_ode(subject: &Subject, params: &[f64]) {
     let ode = equation::ODE::new(
         |x, p, _t, dx, _b, _rateiv, _cov| {
             fetch_params!(p, ka, ke, k12, k21, _v);
@@ -177,7 +177,7 @@ fn two_compartment_oral_ode(subject: &Subject, params: &Vec<f64>) {
     black_box(ode.estimate_predictions(subject, params).unwrap());
 }
 
-fn two_compartment_oral_analytical(subject: &Subject, params: &Vec<f64>) {
+fn two_compartment_oral_analytical(subject: &Subject, params: &[f64]) {
     let analytical = equation::Analytical::new(
         two_compartments_with_absorption,
         |_p, _t, _cov| {},

--- a/src/data/structs.rs
+++ b/src/data/structs.rs
@@ -589,7 +589,7 @@ impl Occasion {
         self.covariates = covariates;
     }
 
-    fn add_lagtime(&mut self, reorder: Option<(&Fa, &Lag, &Vec<f64>, &Covariates)>) {
+    fn add_lagtime(&mut self, reorder: Option<(&Fa, &Lag, &[f64], &Covariates)>) {
         if let Some((_, fn_lag, spp, covariates)) = reorder {
             let spp = nalgebra::DVector::from_vec(spp.to_vec());
             for event in self.events.iter_mut() {
@@ -605,7 +605,7 @@ impl Occasion {
         self.sort();
     }
 
-    fn add_bioavailability(&mut self, reorder: Option<(&Fa, &Lag, &Vec<f64>, &Covariates)>) {
+    fn add_bioavailability(&mut self, reorder: Option<(&Fa, &Lag, &[f64], &Covariates)>) {
         // If lagtime is empty, return early
         if let Some((fn_fa, _, spp, covariates)) = reorder {
             let spp = nalgebra::DVector::from_vec(spp.to_vec());
@@ -663,7 +663,7 @@ impl Occasion {
     /// Vector of events, potentially filtered and with times adjusted for lag and bioavailability
     pub(crate) fn process_events(
         &self,
-        reorder: Option<(&Fa, &Lag, &Vec<f64>, &Covariates)>,
+        reorder: Option<(&Fa, &Lag, &[f64], &Covariates)>,
         ignore: bool,
     ) -> Vec<Event> {
         let mut occ = self.clone();

--- a/src/simulator/equation/analytical/mod.rs
+++ b/src/simulator/equation/analytical/mod.rs
@@ -134,9 +134,9 @@ impl EquationPriv for Analytical {
     fn solve(
         &self,
         x: &mut Self::S,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         covariates: &Covariates,
-        infusions: &Vec<Infusion>,
+        infusions: &[Infusion],
         ti: f64,
         tf: f64,
     ) -> Result<(), PharmsolError> {
@@ -163,7 +163,7 @@ impl EquationPriv for Analytical {
 
         // 2) March over each sub-interval
         let mut current_t = ts[0];
-        let mut sp = V::from_vec(support_point.to_owned(), NalgebraContext);
+        let mut sp = V::from_vec(support_point.to_vec(), NalgebraContext);
         let mut rateiv = V::zeros(self.get_ndrugs(), NalgebraContext);
 
         for &next_t in &ts[1..] {
@@ -199,7 +199,7 @@ impl EquationPriv for Analytical {
     #[inline(always)]
     fn process_observation(
         &self,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         observation: &Observation,
         error_models: Option<&AssayErrorModels>,
         _time: f64,
@@ -212,7 +212,7 @@ impl EquationPriv for Analytical {
         let out = &self.out;
         (out)(
             x,
-            &V::from_vec(support_point.clone(), NalgebraContext),
+            &V::from_vec(support_point.to_vec(), NalgebraContext),
             observation.time(),
             covariates,
             &mut y,
@@ -226,7 +226,7 @@ impl EquationPriv for Analytical {
         Ok(())
     }
     #[inline(always)]
-    fn initial_state(&self, spp: &Vec<f64>, covariates: &Covariates, occasion_index: usize) -> V {
+    fn initial_state(&self, spp: &[f64], covariates: &Covariates, occasion_index: usize) -> V {
         let init = &self.init;
         let mut x = V::zeros(self.get_nstates(), NalgebraContext);
         if occasion_index == 0 {
@@ -374,7 +374,7 @@ impl Equation for Analytical {
     fn estimate_likelihood(
         &self,
         subject: &Subject,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         error_models: &AssayErrorModels,
     ) -> Result<f64, PharmsolError> {
         _estimate_likelihood(self, subject, support_point, error_models)
@@ -383,7 +383,7 @@ impl Equation for Analytical {
     fn estimate_log_likelihood(
         &self,
         subject: &Subject,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         error_models: &AssayErrorModels,
     ) -> Result<f64, PharmsolError> {
         let ypred = _subject_predictions(self, subject, support_point)?;
@@ -399,7 +399,7 @@ impl Equation for Analytical {
 fn _subject_predictions(
     ode: &Analytical,
     subject: &Subject,
-    support_point: &Vec<f64>,
+    support_point: &[f64],
 ) -> Result<SubjectPredictions, PharmsolError> {
     if cache_enabled() {
         let key = (id_hash(subject.id()), spphash(support_point));
@@ -421,7 +421,7 @@ fn _subject_predictions(
 fn _estimate_likelihood(
     ode: &Analytical,
     subject: &Subject,
-    support_point: &Vec<f64>,
+    support_point: &[f64],
     error_models: &AssayErrorModels,
 ) -> Result<f64, PharmsolError> {
     let ypred = _subject_predictions(ode, subject, support_point)?;

--- a/src/simulator/equation/mod.rs
+++ b/src/simulator/equation/mod.rs
@@ -83,9 +83,9 @@ pub(crate) trait EquationPriv: EquationTypes {
     fn solve(
         &self,
         state: &mut Self::S,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         covariates: &Covariates,
-        infusions: &Vec<Infusion>,
+        infusions: &[Infusion],
         start_time: f64,
         end_time: f64,
     ) -> Result<(), PharmsolError>;
@@ -100,7 +100,7 @@ pub(crate) trait EquationPriv: EquationTypes {
     #[allow(clippy::too_many_arguments)]
     fn process_observation(
         &self,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         observation: &Observation,
         error_models: Option<&AssayErrorModels>,
         time: f64,
@@ -112,7 +112,7 @@ pub(crate) trait EquationPriv: EquationTypes {
 
     fn initial_state(
         &self,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         covariates: &Covariates,
         occasion_index: usize,
     ) -> Self::S;
@@ -120,7 +120,7 @@ pub(crate) trait EquationPriv: EquationTypes {
     #[allow(clippy::too_many_arguments)]
     fn simulate_event(
         &self,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         event: &Event,
         next_event: Option<&Event>,
         error_models: Option<&AssayErrorModels>,
@@ -206,7 +206,7 @@ pub trait Equation: EquationPriv + 'static + Clone + Sync {
     fn estimate_likelihood(
         &self,
         subject: &Subject,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         error_models: &AssayErrorModels,
     ) -> Result<f64, PharmsolError>;
 
@@ -229,7 +229,7 @@ pub trait Equation: EquationPriv + 'static + Clone + Sync {
     fn estimate_log_likelihood(
         &self,
         subject: &Subject,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         error_models: &AssayErrorModels,
     ) -> Result<f64, PharmsolError>;
 
@@ -246,7 +246,7 @@ pub trait Equation: EquationPriv + 'static + Clone + Sync {
     fn estimate_predictions(
         &self,
         subject: &Subject,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
     ) -> Result<Self::P, PharmsolError> {
         Ok(self.simulate_subject(subject, support_point, None)?.0)
     }
@@ -273,7 +273,7 @@ pub trait Equation: EquationPriv + 'static + Clone + Sync {
     fn simulate_subject(
         &self,
         subject: &Subject,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         error_models: Option<&AssayErrorModels>,
     ) -> Result<(Self::P, Option<f64>), PharmsolError> {
         let mut output = Self::P::new(self.nparticles());

--- a/src/simulator/equation/ode/mod.rs
+++ b/src/simulator/equation/ode/mod.rs
@@ -138,7 +138,7 @@ impl State for V {
 fn _estimate_likelihood(
     ode: &ODE,
     subject: &Subject,
-    support_point: &Vec<f64>,
+    support_point: &[f64],
     error_models: &AssayErrorModels,
 ) -> Result<f64, PharmsolError> {
     let ypred = _subject_predictions(ode, subject, support_point)?;
@@ -149,7 +149,7 @@ fn _estimate_likelihood(
 fn _subject_predictions(
     ode: &ODE,
     subject: &Subject,
-    support_point: &Vec<f64>,
+    support_point: &[f64],
 ) -> Result<SubjectPredictions, PharmsolError> {
     if cache_enabled() {
         let key = (id_hash(subject.id()), spphash(support_point));
@@ -212,9 +212,9 @@ impl EquationPriv for ODE {
     fn solve(
         &self,
         _state: &mut Self::S,
-        _support_point: &Vec<f64>,
+        _support_point: &[f64],
         _covariates: &Covariates,
-        _infusions: &Vec<Infusion>,
+        _infusions: &[Infusion],
         _start_time: f64,
         _end_time: f64,
     ) -> Result<(), PharmsolError> {
@@ -223,7 +223,7 @@ impl EquationPriv for ODE {
     #[inline(always)]
     fn process_observation(
         &self,
-        _support_point: &Vec<f64>,
+        _support_point: &[f64],
         _observation: &Observation,
         _error_models: Option<&AssayErrorModels>,
         _time: f64,
@@ -236,11 +236,11 @@ impl EquationPriv for ODE {
     }
 
     #[inline(always)]
-    fn initial_state(&self, spp: &Vec<f64>, covariates: &Covariates, occasion_index: usize) -> V {
+    fn initial_state(&self, spp: &[f64], covariates: &Covariates, occasion_index: usize) -> V {
         let init = &self.init;
         let mut x = V::zeros(self.get_nstates(), NalgebraContext);
         if occasion_index == 0 {
-            let spp = DVector::from_vec(spp.clone());
+            let spp = DVector::from_vec(spp.to_vec());
             (init)(&spp.into(), 0.0, covariates, &mut x);
         }
         x
@@ -374,7 +374,7 @@ impl Equation for ODE {
     fn estimate_likelihood(
         &self,
         subject: &Subject,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         error_models: &AssayErrorModels,
     ) -> Result<f64, PharmsolError> {
         _estimate_likelihood(self, subject, support_point, error_models)
@@ -383,7 +383,7 @@ impl Equation for ODE {
     fn estimate_log_likelihood(
         &self,
         subject: &Subject,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         error_models: &AssayErrorModels,
     ) -> Result<f64, PharmsolError> {
         let ypred = _subject_predictions(self, subject, support_point)?;
@@ -397,7 +397,7 @@ impl Equation for ODE {
     fn simulate_subject(
         &self,
         subject: &Subject,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         error_models: Option<&AssayErrorModels>,
     ) -> Result<(Self::P, Option<f64>), PharmsolError> {
         let mut output = Self::P::new(self.nparticles());
@@ -416,7 +416,7 @@ impl Equation for ODE {
         let zero_bolus = V::zeros(ndrugs, NalgebraContext);
         let zero_rateiv = V::zeros(ndrugs, NalgebraContext);
         let mut bolus_v = V::zeros(ndrugs, NalgebraContext);
-        let spp_v: V = DVector::from_vec(support_point.clone()).into();
+        let spp_v: V = DVector::from_vec(support_point.to_vec()).into();
 
         // Pre-allocate output vector for observations
         let mut y_out = V::zeros(self.get_nouteqs(), NalgebraContext);
@@ -435,12 +435,12 @@ impl Equation for ODE {
                 .rtol(self.rtol)
                 .t0(occasion.initial_time())
                 .h0(1e-3)
-                .p(support_point.clone())
+                .p(support_point.to_vec())
                 .build_from_eqn(PMProblem::with_params_v(
                     self.diffeq,
                     nstates,
                     ndrugs,
-                    support_point.clone(),
+                    support_point.to_vec(),
                     spp_v.clone(),
                     covariates,
                     infusions.as_slice(),

--- a/src/simulator/equation/sde/mod.rs
+++ b/src/simulator/equation/sde/mod.rs
@@ -265,9 +265,9 @@ impl EquationPriv for SDE {
     fn solve(
         &self,
         state: &mut Self::S,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         covariates: &Covariates,
-        infusions: &Vec<Infusion>,
+        infusions: &[Infusion],
         ti: f64,
         tf: f64,
     ) -> Result<(), PharmsolError> {
@@ -299,7 +299,7 @@ impl EquationPriv for SDE {
     #[inline(always)]
     fn process_observation(
         &self,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         observation: &crate::Observation,
         error_models: Option<&AssayErrorModels>,
         _time: f64,
@@ -314,7 +314,7 @@ impl EquationPriv for SDE {
             let mut y = V::zeros(self.get_nouteqs(), NalgebraContext);
             (self.out)(
                 &x[i].clone().into(),
-                &V::from_vec(support_point.clone(), NalgebraContext),
+                &V::from_vec(support_point.to_vec(), NalgebraContext),
                 observation.time(),
                 covariates,
                 &mut y,
@@ -349,7 +349,7 @@ impl EquationPriv for SDE {
     #[inline(always)]
     fn initial_state(
         &self,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         covariates: &Covariates,
         occasion_index: usize,
     ) -> Self::S {
@@ -385,7 +385,7 @@ impl Equation for SDE {
     fn estimate_likelihood(
         &self,
         subject: &Subject,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         error_models: &AssayErrorModels,
     ) -> Result<f64, PharmsolError> {
         _estimate_likelihood(self, subject, support_point, error_models)
@@ -394,7 +394,7 @@ impl Equation for SDE {
     fn estimate_log_likelihood(
         &self,
         subject: &Subject,
-        support_point: &Vec<f64>,
+        support_point: &[f64],
         error_models: &AssayErrorModels,
     ) -> Result<f64, PharmsolError> {
         // For SDE, the particle filter computes likelihood in regular space.
@@ -417,7 +417,7 @@ impl Equation for SDE {
 fn _estimate_likelihood(
     sde: &SDE,
     subject: &Subject,
-    support_point: &Vec<f64>,
+    support_point: &[f64],
     error_models: &AssayErrorModels,
 ) -> Result<f64, PharmsolError> {
     if cache_enabled() {

--- a/src/simulator/likelihood/mod.rs
+++ b/src/simulator/likelihood/mod.rs
@@ -184,7 +184,7 @@ pub fn log_likelihood_subject(
     residual_error_models: &crate::ResidualErrorModels,
 ) -> f64 {
     // Simulate to get predictions
-    let predictions = match equation.estimate_predictions(subject, &params.to_vec()) {
+    let predictions = match equation.estimate_predictions(subject, params) {
         Ok(preds) => preds,
         Err(_) => return f64::NEG_INFINITY,
     };

--- a/src/simulator/likelihood/prediction.rs
+++ b/src/simulator/likelihood/prediction.rs
@@ -153,7 +153,7 @@ impl Prediction {
     }
 
     /// Get the state vector at this prediction point
-    pub fn state(&self) -> &Vec<f64> {
+    pub fn state(&self) -> &[f64] {
         &self.state
     }
 


### PR DESCRIPTION
Previously, we have used `Vec` when passing around parameters for models. This signature forces callers to allocate a `Vec` even when the data is already stored elsewhere.

This is technically a breaking change, but trivially fixable for downstream callers (remove `&` from `&vec![...]` or change nothing if already passing a `Vec` by reference).

Part of a larger attempt to reduce memory footprint.