### PR TITLE
feat: Improved cache performance and API

### DIFF
--- a/src/data/structs.rs
+++ b/src/data/structs.rs
@@ -494,6 +494,8 @@ impl Subject {
                     }
                 }
             }
+            // Also hash covariates to ensure that changes are propagated
+            occasion.covariates.hash().hash(&mut hasher);
         }
         hasher.finish()
     }

--- a/src/data/structs.rs
+++ b/src/data/structs.rs
@@ -462,7 +462,7 @@ impl Subject {
 
     /// Calculate the hash for a subject
     ///
-    /// The hash takes into account all events, so that if a subject is modified, it will not produce the same likelihood when simulated with the same support point. Note that covariates are not included in the hash, but a method exists to hash covariates if needed.
+    /// The hash is produced over all events and all covariates of the subject, providing a unique identifier for the subject data.
     pub fn hash(&self) -> u64 {
         use std::hash::{Hash, Hasher};
         let mut hasher = ahash::AHasher::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub mod prelude {
     // Simulator submodule for internal use and advanced users
     pub mod simulator {
         pub use crate::simulator::{
-            cache::{self, CacheSettings},
+            cache::{self, PredictionCache, SdeLikelihoodCache, DEFAULT_CACHE_SIZE},
             equation,
             equation::Equation,
             likelihood::{
@@ -87,7 +87,7 @@ pub mod prelude {
 
     // Direct simulator re-exports for convenience
     pub use crate::simulator::{
-        cache::{configure_cache, disable_cache, enable_cache, reset_caches, CacheSettings},
+        cache::{PredictionCache, SdeLikelihoodCache, DEFAULT_CACHE_SIZE},
         equation::{
             self,
             ode::{ExplicitRkTableau, OdeSolver, SdirkTableau},

--- a/src/simulator/cache.rs
+++ b/src/simulator/cache.rs
@@ -86,7 +86,9 @@ impl fmt::Debug for PredictionCache {
 /// SDEs do not produce subject predictions that can be cached, but
 /// the likelihood values for a given subject and parameters can still be cached.
 ///
-/// Note that the use of a cache for SDEs
+/// Note that the use of a cache could be counterproductive for SDEs, as this removes the
+/// stochastic nature of the likelihood evaluation. However, it can be useful for
+/// producing a deterministic likelihood for an otherwise stochastic process.
 ///
 /// `Clone` produces a shallow clone that shares the same underlying cache data.
 #[derive(Clone)]
@@ -126,5 +128,146 @@ impl fmt::Debug for SdeLikelihoodCache {
         f.debug_struct("SdeLikelihoodCache")
             .field("entry_count", &self.0.entry_count())
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prediction_cache_miss_returns_none() {
+        let cache = PredictionCache::new(10);
+        assert!(cache.get(&(1, 2)).is_none());
+    }
+
+    #[test]
+    fn prediction_cache_hit_returns_value() {
+        let cache = PredictionCache::new(10);
+        let key: PredictionKey = (42, 99);
+        let preds = SubjectPredictions::default();
+        cache.insert(key, preds.clone());
+        assert!(cache.get(&key).is_some());
+    }
+
+    #[test]
+    fn prediction_cache_entry_count() {
+        let cache = PredictionCache::new(10);
+        assert_eq!(cache.entry_count(), 0);
+        cache.insert((1, 1), SubjectPredictions::default());
+        cache.insert((2, 2), SubjectPredictions::default());
+        // moka may need a short sync before entry_count updates
+        cache.0.run_pending_tasks();
+        assert_eq!(cache.entry_count(), 2);
+    }
+
+    #[test]
+    fn prediction_cache_invalidate_all_clears_entries() {
+        let cache = PredictionCache::new(10);
+        cache.insert((1, 1), SubjectPredictions::default());
+        cache.insert((2, 2), SubjectPredictions::default());
+        cache.0.run_pending_tasks();
+        assert_eq!(cache.entry_count(), 2);
+
+        cache.invalidate_all();
+        cache.0.run_pending_tasks();
+        assert_eq!(cache.entry_count(), 0);
+        assert!(cache.get(&(1, 1)).is_none());
+    }
+
+    #[test]
+    fn prediction_cache_overwrite_same_key() {
+        let cache = PredictionCache::new(10);
+        let key: PredictionKey = (1, 1);
+        cache.insert(key, SubjectPredictions::default());
+        cache.insert(key, SubjectPredictions::default());
+        cache.0.run_pending_tasks();
+        assert_eq!(cache.entry_count(), 1);
+    }
+
+    #[test]
+    fn prediction_cache_clone_shares_data() {
+        let cache = PredictionCache::new(10);
+        cache.insert((1, 1), SubjectPredictions::default());
+        let clone = cache.clone();
+        // Clone sees existing entry
+        assert!(clone.get(&(1, 1)).is_some());
+        // Insert via clone is visible through original
+        clone.insert((2, 2), SubjectPredictions::default());
+        assert!(cache.get(&(2, 2)).is_some());
+    }
+
+    #[test]
+    fn prediction_cache_debug_format() {
+        let cache = PredictionCache::new(10);
+        let dbg = format!("{:?}", cache);
+        assert!(dbg.contains("PredictionCache"));
+        assert!(dbg.contains("entry_count"));
+    }
+
+    #[test]
+    fn sde_cache_miss_returns_none() {
+        let cache = SdeLikelihoodCache::new(10);
+        assert!(cache.get(&(1, 2, 3)).is_none());
+    }
+
+    #[test]
+    fn sde_cache_hit_returns_value() {
+        let cache = SdeLikelihoodCache::new(10);
+        let key: SdeKey = (10, 20, 30);
+        cache.insert(key, -42.5);
+        assert_eq!(cache.get(&key), Some(-42.5));
+    }
+
+    #[test]
+    fn sde_cache_entry_count() {
+        let cache = SdeLikelihoodCache::new(10);
+        cache.insert((1, 1, 1), 0.0);
+        cache.insert((2, 2, 2), 1.0);
+        cache.0.run_pending_tasks();
+        assert_eq!(cache.entry_count(), 2);
+    }
+
+    #[test]
+    fn sde_cache_invalidate_all_clears_entries() {
+        let cache = SdeLikelihoodCache::new(10);
+        cache.insert((1, 1, 1), 0.0);
+        cache.insert((2, 2, 2), 1.0);
+        cache.0.run_pending_tasks();
+        assert_eq!(cache.entry_count(), 2);
+
+        cache.invalidate_all();
+        cache.0.run_pending_tasks();
+        assert_eq!(cache.entry_count(), 0);
+        assert!(cache.get(&(1, 1, 1)).is_none());
+    }
+
+    #[test]
+    fn sde_cache_overwrite_same_key() {
+        let cache = SdeLikelihoodCache::new(10);
+        let key: SdeKey = (1, 1, 1);
+        cache.insert(key, 1.0);
+        cache.insert(key, 2.0);
+        cache.0.run_pending_tasks();
+        assert_eq!(cache.entry_count(), 1);
+        assert_eq!(cache.get(&key), Some(2.0));
+    }
+
+    #[test]
+    fn sde_cache_clone_shares_data() {
+        let cache = SdeLikelihoodCache::new(10);
+        cache.insert((1, 1, 1), 5.0);
+        let clone = cache.clone();
+        assert_eq!(clone.get(&(1, 1, 1)), Some(5.0));
+        clone.insert((2, 2, 2), 10.0);
+        assert_eq!(cache.get(&(2, 2, 2)), Some(10.0));
+    }
+
+    #[test]
+    fn sde_cache_debug_format() {
+        let cache = SdeLikelihoodCache::new(10);
+        let dbg = format!("{:?}", cache);
+        assert!(dbg.contains("SdeLikelihoodCache"));
+        assert!(dbg.contains("entry_count"));
     }
 }

--- a/src/simulator/cache.rs
+++ b/src/simulator/cache.rs
@@ -1,199 +1,130 @@
-//! Global cache for predictions
+//! Cache mechanisms for [Equation]s
 //!
-//! This module provides a configurable, concurrent LRU cache for prediction results.
-//! The supports enabling/disabling caching at runtime and adjusting cache size.
-//!
-//! The cache can be cleared between runs, which is useful to avoid stale data and bad hits.
-
+//! This module provides lightweight cache wrappers that can be embedded
+//! directly in equation structs ([`ODE`], [`Analytical`], [`SDE`]).
+//! Each equation instance can optionally own a cache; cloning the equation
+//! produces a shallow clone that shares the same cache data.
 //!
 //! # Example
 //! ```ignore
-//! use pharmsol::simulator::cache::{configure_cache, CacheSettings};
+//! use pharmsol::*;
 //!
-//! // Use a smaller cache
-//! configure_cache(CacheSettings::with_size(10_000));
+//! // No caching (default):
+//! let ode = ODE::new(diffeq, lag, fa, init, out);
 //!
-//! // Disable caching entirely
-//! configure_cache(CacheSettings::disabled());
+//! // Enable caching with default size:
+//! let ode = ODE::new(diffeq, lag, fa, init, out).with_default_cache();
+//!
+//! // Enable caching with custom size:
+//! let ode = ODE::new(diffeq, lag, fa, init, out).with_cache(50_000);
 //! ```
 
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    LazyLock, RwLock,
-};
+use std::fmt;
 
 use moka::sync::Cache;
 
-use crate::{simulator::likelihood::SubjectPredictions, PharmsolError};
+use crate::simulator::likelihood::SubjectPredictions;
 
 /// Default maximum number of entries per cache.
 pub const DEFAULT_CACHE_SIZE: u64 = 100_000;
 
-static CACHE_ENABLED: AtomicBool = AtomicBool::new(true);
-
-/// Settings for the prediction cache.
-#[derive(Debug, Clone)]
-pub struct CacheSettings {
-    /// Whether caching is enabled.
-    pub enabled: bool,
-    /// Maximum number of entries per equation type.
-    pub size: u64,
-}
-
-impl Default for CacheSettings {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            size: DEFAULT_CACHE_SIZE,
-        }
-    }
-}
-
-impl CacheSettings {
-    /// Create settings with caching disabled.
-    pub fn disabled() -> Self {
-        Self {
-            enabled: false,
-            ..Default::default()
-        }
-    }
-
-    /// Create settings with a custom cache size.
-    pub fn with_size(size: u64) -> Self {
-        Self {
-            enabled: true,
-            size,
-        }
-    }
-}
-
-/// Apply new cache settings globally.
-///
-/// This replaces all caches with new instances of the given size
-/// and updates the enabled flag. Any cached entries are discarded.
-pub fn configure_cache(settings: CacheSettings) -> Result<(), PharmsolError> {
-    CACHE_ENABLED.store(settings.enabled, Ordering::Relaxed);
-
-    let size = settings.size;
-
-    // Replace each cache with a fresh instance of the requested size.
-    {
-        let mut c = ana_cache_lock_write()?;
-        *c = Cache::new(size);
-    }
-    {
-        let mut c = ode_cache_lock_write()?;
-        *c = Cache::new(size);
-    }
-    {
-        let mut c = sde_cache_lock_write()?;
-        *c = Cache::new(size);
-    }
-
-    Ok(())
-}
-
-/// Clear all prediction caches without changing settings.
-pub fn reset_caches() -> Result<(), PharmsolError> {
-    ana_cache_lock_read()?.invalidate_all();
-    ode_cache_lock_read()?.invalidate_all();
-    sde_cache_lock_read()?.invalidate_all();
-    Ok(())
-}
-
-/// Disable caching entirely and clear all caches.
-pub fn disable_cache() -> Result<(), PharmsolError> {
-    CACHE_ENABLED.store(false, Ordering::Relaxed);
-    reset_caches()
-}
-
-/// Enable caching (uses existing size settings).
-pub fn enable_cache() {
-    CACHE_ENABLED.store(true, Ordering::Relaxed);
-}
-
-/// Returns `true` if caching is currently enabled.
-#[inline(always)]
-pub fn cache_enabled() -> bool {
-    CACHE_ENABLED.load(Ordering::Relaxed)
-}
-
-/// Get the current cache settings.
-pub fn cache_settings() -> Result<CacheSettings, PharmsolError> {
-    let size = ana_cache_lock_read()?.policy().max_capacity().unwrap_or(0);
-    Ok(CacheSettings {
-        enabled: cache_enabled(),
-        size,
-    })
-}
-
-// ---------------------------------------------------------------------------
-// Per-equation-type caches
-// ---------------------------------------------------------------------------
-
-/// Cache key: (subject_id_hash, support_point_hash)
+/// Cache key: (subject_hash, support_point_hash)
 pub(crate) type PredictionKey = (u64, u64);
 
-/// Cache key for SDE: (subject_id_hash, support_point_hash, error_model_hash)
+/// Cache key for SDE: (subject_hash, support_point_hash, error_model_hash)
 pub(crate) type SdeKey = (u64, u64, u64);
 
-// The caches use RwLock so that the hot path (read lock) allows full moka
-// concurrency, while resize (write lock) is exclusive but rare.
+/// Thread-safe LRU cache for subject predictions.
+///
+/// Used by [`ODE`](crate::ODE) and [`Analytical`](crate::simulator::equation::Analytical)
+/// to avoid recomputing predictions for the same (subject, parameters) pair.
+///
+/// `Clone` produces a shallow clone that shares the same underlying cache data,
+/// so cloned equations share cache hits.
+#[derive(Clone)]
+pub struct PredictionCache(Cache<PredictionKey, SubjectPredictions>);
 
-static ANA_CACHE: LazyLock<RwLock<Cache<PredictionKey, SubjectPredictions>>> =
-    LazyLock::new(|| RwLock::new(Cache::new(DEFAULT_CACHE_SIZE)));
+impl PredictionCache {
+    /// Create a new prediction cache with a given maximum number of entries.
+    pub fn new(size: u64) -> Self {
+        Self(Cache::new(size))
+    }
 
-static ODE_CACHE: LazyLock<RwLock<Cache<PredictionKey, SubjectPredictions>>> =
-    LazyLock::new(|| RwLock::new(Cache::new(DEFAULT_CACHE_SIZE)));
+    /// Look up a cached prediction.
+    #[inline]
+    pub fn get(&self, key: &PredictionKey) -> Option<SubjectPredictions> {
+        self.0.get(key)
+    }
 
-static SDE_CACHE: LazyLock<RwLock<Cache<SdeKey, f64>>> =
-    LazyLock::new(|| RwLock::new(Cache::new(DEFAULT_CACHE_SIZE)));
+    /// Insert a prediction into the cache.
+    #[inline]
+    pub fn insert(&self, key: PredictionKey, value: SubjectPredictions) {
+        self.0.insert(key, value);
+    }
 
-/// Wrapper for lock errors
-fn lock_err(context: &str) -> PharmsolError {
-    PharmsolError::OtherError(format!("Failed to lock {context} cache"))
+    /// Remove all entries from the cache.
+    pub fn invalidate_all(&self) {
+        self.0.invalidate_all();
+    }
+
+    /// Return the number of entries currently in the cache.
+    pub fn entry_count(&self) -> u64 {
+        self.0.entry_count()
+    }
 }
 
-// -- Analytical --
-
-pub(crate) fn ana_cache_lock_read() -> Result<
-    std::sync::RwLockReadGuard<'static, Cache<PredictionKey, SubjectPredictions>>,
-    PharmsolError,
-> {
-    ANA_CACHE.read().map_err(|_| lock_err("analytical"))
+impl fmt::Debug for PredictionCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PredictionCache")
+            .field("entry_count", &self.0.entry_count())
+            .finish()
+    }
 }
 
-fn ana_cache_lock_write() -> Result<
-    std::sync::RwLockWriteGuard<'static, Cache<PredictionKey, SubjectPredictions>>,
-    PharmsolError,
-> {
-    ANA_CACHE.write().map_err(|_| lock_err("analytical"))
+/// Cache for SDE likelihood values.
+///
+/// SDEs do not produce subject predictions that can be cached, but
+/// the likelihood values for a given subject and parameters can still be cached.
+///
+/// Note that the use of a cache for SDEs
+///
+/// `Clone` produces a shallow clone that shares the same underlying cache data.
+#[derive(Clone)]
+pub struct SdeLikelihoodCache(Cache<SdeKey, f64>);
+
+impl SdeLikelihoodCache {
+    /// Create a new SDE likelihood cache with the given maximum number of entries.
+    pub fn new(size: u64) -> Self {
+        Self(Cache::new(size))
+    }
+
+    /// Look up a cached likelihood value.
+    #[inline]
+    pub fn get(&self, key: &SdeKey) -> Option<f64> {
+        self.0.get(key)
+    }
+
+    /// Insert a likelihood value into the cache.
+    #[inline]
+    pub fn insert(&self, key: SdeKey, value: f64) {
+        self.0.insert(key, value);
+    }
+
+    /// Remove all entries from the cache.
+    pub fn invalidate_all(&self) {
+        self.0.invalidate_all();
+    }
+
+    /// Return the number of entries currently in the cache.
+    pub fn entry_count(&self) -> u64 {
+        self.0.entry_count()
+    }
 }
 
-// -- ODE --
-
-pub(crate) fn ode_cache_lock_read() -> Result<
-    std::sync::RwLockReadGuard<'static, Cache<PredictionKey, SubjectPredictions>>,
-    PharmsolError,
-> {
-    ODE_CACHE.read().map_err(|_| lock_err("ODE"))
-}
-
-fn ode_cache_lock_write() -> Result<
-    std::sync::RwLockWriteGuard<'static, Cache<PredictionKey, SubjectPredictions>>,
-    PharmsolError,
-> {
-    ODE_CACHE.write().map_err(|_| lock_err("ODE"))
-}
-
-// -- SDE --
-
-pub(crate) fn sde_cache_lock_read(
-) -> Result<std::sync::RwLockReadGuard<'static, Cache<SdeKey, f64>>, PharmsolError> {
-    SDE_CACHE.read().map_err(|_| lock_err("SDE"))
-}
-
-fn sde_cache_lock_write(
-) -> Result<std::sync::RwLockWriteGuard<'static, Cache<SdeKey, f64>>, PharmsolError> {
-    SDE_CACHE.write().map_err(|_| lock_err("SDE"))
+impl fmt::Debug for SdeLikelihoodCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SdeLikelihoodCache")
+            .field("entry_count", &self.0.entry_count())
+            .finish()
+    }
 }

--- a/src/simulator/equation/analytical/mod.rs
+++ b/src/simulator/equation/analytical/mod.rs
@@ -13,11 +13,10 @@ pub use three_compartment_models::*;
 pub use two_compartment_cl_models::*;
 pub use two_compartment_models::*;
 
-use super::id_hash;
 use super::spphash;
 
 use crate::data::error_model::AssayErrorModels;
-use crate::simulator::cache::{ana_cache_lock_read, cache_enabled};
+use crate::simulator::cache::{PredictionCache, DEFAULT_CACHE_SIZE};
 use crate::PharmsolError;
 use crate::{
     data::Covariates, simulator::*, Equation, EquationPriv, EquationTypes, Observation, Subject,
@@ -27,7 +26,6 @@ use crate::{
 ///
 /// This implementation uses closed-form analytical solutions for the model
 /// equations rather than numerical integration.
-#[repr(C)]
 #[derive(Clone, Debug)]
 pub struct Analytical {
     eq: AnalyticalEq,
@@ -37,6 +35,7 @@ pub struct Analytical {
     init: Init,
     out: Out,
     neqs: Neqs,
+    cache: Option<PredictionCache>,
 }
 
 impl Analytical {
@@ -58,6 +57,7 @@ impl Analytical {
             init,
             out,
             neqs: Neqs::default(),
+            cache: None,
         }
     }
 
@@ -77,6 +77,28 @@ impl Analytical {
     pub fn with_nout(mut self, nout: usize) -> Self {
         self.neqs.nout = nout;
         self
+    }
+
+    /// Enable prediction caching with the given maximum number of entries.
+    ///
+    /// When caching is enabled, predictions for the same (subject, parameters)
+    /// pair are stored and reused. Cloned equations share the same cache.
+    pub fn with_cache(mut self, size: u64) -> Self {
+        self.cache = Some(PredictionCache::new(size));
+        self
+    }
+
+    /// Enable prediction caching with the default size (100,000 entries).
+    pub fn with_default_cache(mut self) -> Self {
+        self.cache = Some(PredictionCache::new(DEFAULT_CACHE_SIZE));
+        self
+    }
+
+    /// Clear all entries from this equation's cache, if caching is enabled.
+    pub fn clear_cache(&self) {
+        if let Some(cache) = &self.cache {
+            cache.invalidate_all();
+        }
     }
 }
 
@@ -397,24 +419,21 @@ impl Equation for Analytical {
 
 #[inline(always)]
 fn _subject_predictions(
-    ode: &Analytical,
+    analytical: &Analytical,
     subject: &Subject,
     support_point: &Vec<f64>,
 ) -> Result<SubjectPredictions, PharmsolError> {
-    if cache_enabled() {
-        let key = (id_hash(subject.id()), spphash(support_point));
-        let cache_guard = ana_cache_lock_read()?;
-        if let Some(cached) = cache_guard.get(&key) {
+    if let Some(cache) = &analytical.cache {
+        let key = (subject.hash(), spphash(support_point));
+        if let Some(cached) = cache.get(&key) {
             return Ok(cached);
         }
-        drop(cache_guard);
 
-        let result = ode.simulate_subject(subject, support_point, None)?.0;
-        let cache_guard = ana_cache_lock_read()?;
-        cache_guard.insert(key, result.clone());
+        let result = analytical.simulate_subject(subject, support_point, None)?.0;
+        cache.insert(key, result.clone());
         Ok(result)
     } else {
-        Ok(ode.simulate_subject(subject, support_point, None)?.0)
+        Ok(analytical.simulate_subject(subject, support_point, None)?.0)
     }
 }
 

--- a/src/simulator/equation/mod.rs
+++ b/src/simulator/equation/mod.rs
@@ -324,15 +324,6 @@ impl EqnKind {
     }
 }
 
-/// Hash a subject for cache key generation.
-#[inline(always)]
-fn id_hash(id: &str) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = ahash::AHasher::default();
-    id.hash(&mut hasher);
-    hasher.finish()
-}
-
 /// Hash support points to a u64 for cache key generation.
 #[inline(always)]
 fn spphash(spp: &[f64]) -> u64 {

--- a/src/simulator/equation/ode/mod.rs
+++ b/src/simulator/equation/ode/mod.rs
@@ -8,9 +8,8 @@ use crate::{
     Event, Observation, PharmsolError, Subject,
 };
 
-use super::id_hash;
 use super::spphash;
-use crate::simulator::cache::{cache_enabled, ode_cache_lock_read};
+use crate::simulator::cache::{PredictionCache, DEFAULT_CACHE_SIZE};
 use crate::simulator::equation::Predictions;
 use closure::PMProblem;
 use diffsol::{
@@ -67,7 +66,6 @@ pub enum ExplicitRkTableau {
     Tsit45,
 }
 
-#[repr(C)]
 #[derive(Clone, Debug)]
 pub struct ODE {
     diffeq: DiffEq,
@@ -79,6 +77,7 @@ pub struct ODE {
     solver: OdeSolver,
     rtol: f64,
     atol: f64,
+    cache: Option<PredictionCache>,
 }
 
 impl ODE {
@@ -93,6 +92,7 @@ impl ODE {
             solver: OdeSolver::default(),
             rtol: RTOL,
             atol: ATOL,
+            cache: None,
         }
     }
 
@@ -126,6 +126,28 @@ impl ODE {
         self.atol = atol;
         self
     }
+
+    /// Enable prediction caching with the given maximum number of entries.
+    ///
+    /// When caching is enabled, predictions for the same (subject, parameters)
+    /// pair are stored and reused. Cloned equations share the same cache.
+    pub fn with_cache(mut self, size: u64) -> Self {
+        self.cache = Some(PredictionCache::new(size));
+        self
+    }
+
+    /// Enable prediction caching with the default size (100,000 entries).
+    pub fn with_default_cache(mut self) -> Self {
+        self.cache = Some(PredictionCache::new(DEFAULT_CACHE_SIZE));
+        self
+    }
+
+    /// Clear all entries from this equation's cache, if caching is enabled.
+    pub fn clear_cache(&self) {
+        if let Some(cache) = &self.cache {
+            cache.invalidate_all();
+        }
+    }
 }
 
 impl State for V {
@@ -151,17 +173,14 @@ fn _subject_predictions(
     subject: &Subject,
     support_point: &Vec<f64>,
 ) -> Result<SubjectPredictions, PharmsolError> {
-    if cache_enabled() {
-        let key = (id_hash(subject.id()), spphash(support_point));
-        let cache_guard = ode_cache_lock_read()?;
-        if let Some(cached) = cache_guard.get(&key) {
+    if let Some(cache) = &ode.cache {
+        let key = (subject.hash(), spphash(support_point));
+        if let Some(cached) = cache.get(&key) {
             return Ok(cached);
         }
-        drop(cache_guard);
 
         let result = ode.simulate_subject(subject, support_point, None)?.0;
-        let cache_guard = ode_cache_lock_read()?;
-        cache_guard.insert(key, result.clone());
+        cache.insert(key, result.clone());
         Ok(result)
     } else {
         Ok(ode.simulate_subject(subject, support_point, None)?.0)

--- a/src/simulator/equation/sde/mod.rs
+++ b/src/simulator/equation/sde/mod.rs
@@ -14,9 +14,8 @@ use crate::{
     Subject,
 };
 
-use super::id_hash;
 use super::spphash;
-use crate::simulator::cache::{cache_enabled, sde_cache_lock_read};
+use crate::simulator::cache::{SdeLikelihoodCache, DEFAULT_CACHE_SIZE};
 
 use diffsol::VectorCommon;
 
@@ -91,6 +90,7 @@ pub struct SDE {
     out: Out,
     neqs: Neqs,
     nparticles: usize,
+    cache: Option<SdeLikelihoodCache>,
 }
 
 impl SDE {
@@ -121,6 +121,7 @@ impl SDE {
             out,
             neqs: Neqs::default(),
             nparticles,
+            cache: None,
         }
     }
 
@@ -140,6 +141,29 @@ impl SDE {
     pub fn with_nout(mut self, nout: usize) -> Self {
         self.neqs.nout = nout;
         self
+    }
+
+    /// Enable likelihood caching with the given maximum number of entries.
+    ///
+    /// When caching is enabled, likelihood results for the same
+    /// (subject, parameters, error model) triple are stored and reused.
+    /// Cloned equations share the same cache.
+    pub fn with_cache(mut self, size: u64) -> Self {
+        self.cache = Some(SdeLikelihoodCache::new(size));
+        self
+    }
+
+    /// Enable likelihood caching with the default size (100,000 entries).
+    pub fn with_default_cache(mut self) -> Self {
+        self.cache = Some(SdeLikelihoodCache::new(DEFAULT_CACHE_SIZE));
+        self
+    }
+
+    /// Clear all entries from this equation's cache, if caching is enabled.
+    pub fn clear_cache(&self) {
+        if let Some(cache) = &self.cache {
+            cache.invalidate_all();
+        }
     }
 }
 
@@ -420,22 +444,15 @@ fn _estimate_likelihood(
     support_point: &Vec<f64>,
     error_models: &AssayErrorModels,
 ) -> Result<f64, PharmsolError> {
-    if cache_enabled() {
-        let key = (
-            id_hash(subject.id()),
-            spphash(support_point),
-            error_models.hash(),
-        );
-        let cache_guard = sde_cache_lock_read()?;
-        if let Some(cached) = cache_guard.get(&key) {
+    if let Some(cache) = &sde.cache {
+        let key = (subject.hash(), spphash(support_point), error_models.hash());
+        if let Some(cached) = cache.get(&key) {
             return Ok(cached);
         }
-        drop(cache_guard);
 
         let ypred = sde.simulate_subject(subject, support_point, Some(error_models))?;
         let result = ypred.1.unwrap();
-        let cache_guard = sde_cache_lock_read()?;
-        cache_guard.insert(key, result);
+        cache.insert(key, result);
         Ok(result)
     } else {
         let ypred = sde.simulate_subject(subject, support_point, Some(error_models))?;

--- a/src/simulator/mod.rs
+++ b/src/simulator/mod.rs
@@ -234,8 +234,5 @@ impl Default for Neqs {
     }
 }
 
-// Re-export cache API at the simulator level for convenience.
-pub use cache::{
-    cache_enabled, cache_settings, configure_cache, disable_cache, enable_cache, reset_caches,
-    CacheSettings,
-};
+// Re-export cache types at the simulator level for convenience.
+pub use cache::{PredictionCache, SdeLikelihoodCache, DEFAULT_CACHE_SIZE};


### PR DESCRIPTION
Instead of a global cache for each equation type, it makes much more sense to have the cache as part of the `Equation` structure. 