### PR TITLE
fix: DSL tests

### DIFF
--- a/pharmsol-dsl/src/ir.rs
+++ b/pharmsol-dsl/src/ir.rs
@@ -472,6 +472,9 @@ where
         }
 
         let lookup = candidate.to_ascii_lowercase();
+        if differs_only_by_trailing_digits(&needle, &lookup) {
+            continue;
+        }
         let distance = if is_single_adjacent_transposition(&needle, &lookup) {
             1
         } else {
@@ -506,6 +509,18 @@ where
     } else {
         best.map(|(_, candidate)| candidate)
     }
+}
+
+fn differs_only_by_trailing_digits(lhs: &str, rhs: &str) -> bool {
+    let (shorter, longer) = if lhs.len() < rhs.len() {
+        (lhs, rhs)
+    } else {
+        (rhs, lhs)
+    };
+    if shorter.is_empty() || shorter == longer {
+        return false;
+    }
+    longer.starts_with(shorter) && longer[shorter.len()..].chars().all(|c| c.is_ascii_digit())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/pharmsol-macros/src/lib.rs
+++ b/pharmsol-macros/src/lib.rs
@@ -3769,7 +3769,7 @@ mod tests {
     #[test]
     fn ode_route_bindings_share_inputs_by_kind_local_ordinal() {
         let input = syn::parse_str::<OdeInput>(
-            "name: \"demo\", params: [ka, ke, v], states: [depot, central], outputs: [cp], routes: [bolus(oral) -> depot, infusion(iv) -> central, bolus(sc) -> depot], diffeq: |x, p, t, dx, b, rateiv, cov| {}, out: |x, p, t, cov, y| {}",
+            "name: \"demo\", params: [ka, ke, v], states: [depot, central], outputs: [cp], routes: [bolus(oral) -> depot, infusion(iv) -> central, bolus(sc) -> depot], diffeq: |x, p, t, dx, cov| {}, out: |x, p, t, cov, y| {}",
         )
         .expect("declaration-first ode input should parse");
 


### PR DESCRIPTION
- pharmsol-dsl: don't suggest `ka0` as a typo for missing `ka` (filter candidates that differ from the needle only by trailing ASCII digits)
- pharmsol-macros: update `ode_route_bindings_share_inputs_by_kind_local_ordinal` fixture to a supported 5-arg `diffeq` closure