### PR TITLE
fix: Fix data expansion

### DIFF
--- a/src/data/parser/pmetrics.rs
+++ b/src/data/parser/pmetrics.rs
@@ -316,7 +316,7 @@ impl Data {
 
         for subject in self.subjects() {
             for occasion in subject.occasions() {
-                for event in occasion.process_events(None, false) {
+                for event in occasion.process_events(None) {
                     match event {
                         Event::Observation(obs) => {
                             let time = obs.time().to_string();

--- a/src/data/structs.rs
+++ b/src/data/structs.rs
@@ -144,7 +144,7 @@ impl Data {
     /// # Arguments
     ///
     /// * `idelta` - Time interval between added observations
-    /// * `tad` - Additional time to add after the last observation
+    /// * `tad` - Additional time to add after the last dose (time after dose)
     ///
     /// # Returns
     ///
@@ -154,21 +154,6 @@ impl Data {
             return self.clone();
         }
 
-        // Determine the last time across all subjects and occasions
-        let last_time = self
-            .subjects
-            .iter()
-            .flat_map(|subject| &subject.occasions)
-            .flat_map(|occasion| &occasion.events)
-            .filter_map(|event| match event {
-                Event::Observation(observation) => Some(observation.time()),
-                Event::Infusion(infusion) => Some(infusion.time() + infusion.duration()),
-                _ => None,
-            })
-            .max_by(|a, b| a.partial_cmp(b).unwrap())
-            .unwrap_or(0.0)
-            + tad;
-
         // Collect unique output equations more efficiently
         let outeq_values = self.get_output_equations();
 
@@ -177,6 +162,20 @@ impl Data {
             .subjects
             .iter()
             .map(|subject| {
+                // Determine the last dose time for this subject across its occasions
+                let last_time = subject
+                    .occasions
+                    .iter()
+                    .flat_map(|occasion| &occasion.events)
+                    .filter_map(|event| match event {
+                        Event::Bolus(bolus) => Some(bolus.time()),
+                        Event::Infusion(infusion) => Some(infusion.time() + infusion.duration()),
+                        _ => None,
+                    })
+                    .max_by(|a, b| a.partial_cmp(b).unwrap())
+                    .unwrap_or(0.0)
+                    + tad;
+
                 let new_occasions = subject
                     .occasions
                     .iter()
@@ -200,7 +199,7 @@ impl Data {
                         // Generate new observation times
                         let mut new_events = Vec::new();
                         let mut time = 0.0;
-                        while time < last_time {
+                        while time <= last_time {
                             let time_key = (time * 1e6).round() as u64;
 
                             for outeq in &outeq_values {

--- a/src/data/structs.rs
+++ b/src/data/structs.rs
@@ -1583,4 +1583,58 @@ mod tests {
             .build();
         assert_eq!(a.hash(), b.hash());
     }
+
+    #[test]
+    fn expand_grid_reaches_last_dose_plus_tad() {
+        // Single occasion: last dose at t=0, tad extends the grid to t=3 inclusive
+        let subject = Subject::builder("s1")
+            .bolus(0.0, 100.0, 0)
+            .observation(0.0, 5.0, 0)
+            .build();
+        let data = Data::from(subject);
+
+        let expanded = data.expand(1.0, 3.0);
+        let occasion = &expanded.subjects()[0].occasions()[0];
+
+        let mut obs_times: Vec<f64> = occasion
+            .events()
+            .iter()
+            .filter_map(|e| match e {
+                Event::Observation(o) => Some(o.time()),
+                _ => None,
+            })
+            .collect();
+        obs_times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+        // Grid at 0,1,2,3 (last dose 0 + tad 3), endpoint included
+        assert_eq!(obs_times, vec![0.0, 1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn expand_last_time_is_per_occasion() {
+        // Occasion 0 dosed at t=0, occasion 1 dosed at t=10
+        let subject = Subject::builder("s1")
+            .bolus(0.0, 100.0, 0)
+            .observation(0.0, 5.0, 0)
+            .reset()
+            .bolus(10.0, 100.0, 0)
+            .observation(10.0, 5.0, 0)
+            .build();
+        let data = Data::from(subject);
+
+        let expanded = data.expand(5.0, 0.0);
+        let subject = &expanded.subjects()[0];
+
+        let count_obs = |occ: &Occasion| {
+            occ.events()
+                .iter()
+                .filter(|e| matches!(e, Event::Observation(_)))
+                .count()
+        };
+
+        // Occasion 0: last dose = 0, grid only at t=0 (already present) -> 1 observation
+        assert_eq!(count_obs(&subject.occasions()[0]), 1);
+        // Occasion 1: last dose = 10, grid at 0,5,10 -> 2 generated + 1 real = 3
+        assert_eq!(count_obs(&subject.occasions()[1]), 3);
+    }
 }

--- a/src/data/structs.rs
+++ b/src/data/structs.rs
@@ -162,25 +162,26 @@ impl Data {
             .subjects
             .iter()
             .map(|subject| {
-                // Determine the last dose time for this subject across its occasions
-                let last_time = subject
-                    .occasions
-                    .iter()
-                    .flat_map(|occasion| &occasion.events)
-                    .filter_map(|event| match event {
-                        Event::Bolus(bolus) => Some(bolus.time()),
-                        Event::Infusion(infusion) => Some(infusion.time() + infusion.duration()),
-                        _ => None,
-                    })
-                    .max_by(|a, b| a.partial_cmp(b).unwrap())
-                    .unwrap_or(0.0)
-                    + tad;
-
                 let new_occasions = subject
                     .occasions
                     .iter()
                     .map(|occasion| {
-                        let old_events = occasion.process_events(None, true);
+                        let old_events = occasion.process_events(None);
+
+                        // Determine the last dose time for this occasion
+                        let last_time = occasion
+                            .events
+                            .iter()
+                            .filter_map(|event| match event {
+                                Event::Bolus(bolus) => Some(bolus.time()),
+                                Event::Infusion(infusion) => {
+                                    Some(infusion.time() + infusion.duration())
+                                }
+                                _ => None,
+                            })
+                            .max_by(|a, b| a.partial_cmp(b).unwrap())
+                            .unwrap_or(0.0)
+                            + tad;
 
                         // Create a set of existing (time, outeq) pairs for fast lookup
                         let existing_obs: std::collections::HashSet<(u64, OutputLabel)> =
@@ -671,7 +672,6 @@ impl Occasion {
     pub(crate) fn process_events(
         &self,
         reorder: Option<(&Fa, &Lag, &[f64], &Covariates)>,
-        _ignore: bool,
     ) -> Vec<Event> {
         let mut occ = self.clone();
         occ.add_lagtime(reorder);
@@ -1141,7 +1141,7 @@ mod tests {
         occasion.add_observation(2.0, 1.0, 1, None, Censor::None);
         occasion.add_bolus(1.0, 100.0, 1);
         occasion.sort();
-        let events = occasion.process_events(None, false);
+        let events = occasion.process_events(None);
         match &events[0] {
             Event::Bolus(b) => assert_eq!(b.time(), 1.0),
             _ => panic!("First event should be a Bolus (earlier time)"),
@@ -1158,7 +1158,7 @@ mod tests {
         occasion.add_bolus(1.0, 100.0, 1);
         occasion.add_observation(1.0, 5.0, 1, None, Censor::None);
         occasion.sort();
-        let events = occasion.process_events(None, false);
+        let events = occasion.process_events(None);
         assert_eq!(events.len(), 2);
         match &events[0] {
             Event::Observation(o) => assert_eq!(o.time(), 1.0),
@@ -1176,7 +1176,7 @@ mod tests {
         occasion.add_infusion(1.0, 100.0, 1, 0.5);
         occasion.add_observation(1.0, 5.0, 1, None, Censor::None);
         occasion.sort();
-        let events = occasion.process_events(None, false);
+        let events = occasion.process_events(None);
         assert_eq!(events.len(), 2);
         match &events[0] {
             Event::Observation(o) => assert_eq!(o.time(), 1.0),
@@ -1196,7 +1196,7 @@ mod tests {
         occasion.add_bolus(0.0, 100.0, 1);
         occasion.add_observation(0.0, 0.0, 1, None, Censor::None);
         occasion.sort();
-        let events = occasion.process_events(None, false);
+        let events = occasion.process_events(None);
         assert_eq!(events.len(), 3);
         assert!(
             matches!(&events[0], Event::Observation(_)),
@@ -1224,7 +1224,7 @@ mod tests {
         occasion.add_observation(2.0, 3.0, 1, None, Censor::None);
         occasion.add_bolus(2.0, 100.0, 1);
         occasion.sort();
-        let events = occasion.process_events(None, false);
+        let events = occasion.process_events(None);
         assert_eq!(events.len(), 5);
         // t=0: observation before bolus
         assert!(matches!(&events[0], Event::Observation(o) if o.time() == 0.0));

--- a/src/data/structs.rs
+++ b/src/data/structs.rs
@@ -143,7 +143,10 @@ impl Data {
     ///
     /// # Arguments
     ///
-    /// * `idelta` - Time interval between added observations
+    /// * `idelta` - Time interval between added observations. Times are handled
+    ///   with microsecond resolution, so `idelta` must be at least `5e-7`
+    ///   (0.5 µs, which rounds up to 1 µs); any smaller positive value rounds
+    ///   to zero and the dataset is returned unchanged.
     /// * `tad` - Additional time to add after the last dose (time after dose)
     ///
     /// # Returns
@@ -151,6 +154,14 @@ impl Data {
     /// A new `Data` object with expanded observations
     pub fn expand(&self, idelta: f64, tad: f64) -> Data {
         if idelta <= 0.0 {
+            return self.clone();
+        }
+
+        // Work in integer microseconds so the grid always makes progress.
+        // A sub-microsecond `idelta` would otherwise round back to the previous
+        // time on every iteration and spin forever.
+        let step_us = (idelta * 1e6).round() as u64;
+        if step_us == 0 {
             return self.clone();
         }
 
@@ -197,11 +208,13 @@ impl Data {
                                 })
                                 .collect();
 
-                        // Generate new observation times
+                        // Generate new observation times, stepping in integer
+                        // microseconds to guarantee forward progress.
                         let mut new_events = Vec::new();
-                        let mut time = 0.0;
-                        while time <= last_time {
-                            let time_key = (time * 1e6).round() as u64;
+                        let last_time_us = (last_time * 1e6).round() as u64;
+                        let mut time_key = 0u64;
+                        while time_key <= last_time_us {
+                            let time = time_key as f64 / 1e6;
 
                             for outeq in &outeq_values {
                                 // Only add if this (time, outeq) combination doesn't exist
@@ -218,8 +231,7 @@ impl Data {
                                 }
                             }
 
-                            time += idelta;
-                            time = (time * 1e6).round() / 1e6;
+                            time_key += step_us;
                         }
 
                         // Add original events

--- a/src/dsl/native.rs
+++ b/src/dsl/native.rs
@@ -746,7 +746,7 @@ impl SharedNativeModel {
     }
 
     fn resolve_events(&self, occasion: &Occasion) -> Result<Vec<Event>, PharmsolError> {
-        let mut events = occasion.process_events(None, true);
+        let mut events = occasion.process_events(None);
 
         for event in events.iter_mut() {
             match event {

--- a/src/simulator/equation/mod.rs
+++ b/src/simulator/equation/mod.rs
@@ -274,7 +274,7 @@ pub(crate) trait EquationPriv: EquationTypes {
             }
         }
 
-        Ok(resolved.process_events(Some((self.fa(), self.lag(), parameters, covariates)), true))
+        Ok(resolved.process_events(Some((self.fa(), self.lag(), parameters, covariates))))
     }
     #[allow(dead_code)]
     fn is_sde(&self) -> bool {


### PR DESCRIPTION
Now uses each subjects maximal time, instead of the global max time.

TAD is now applied after the last dose, not the last observation.