### PR TITLE
feat: Support time in the DSL

### DIFF
--- a/pharmsol-dsl/src/analysis.rs
+++ b/pharmsol-dsl/src/analysis.rs
@@ -612,6 +612,8 @@ pub enum AnalyzedExprKind {
     Literal(ConstValue),
     Symbol(SymbolId),
     StateValue(AnalyzedStatePlace),
+    /// The current independent variable (time), referenced in source as `t`.
+    Time,
     Unary {
         op: AnalyzedUnaryOp,
         expr: Box<AnalyzedExpr>,

--- a/pharmsol-dsl/src/analyze.rs
+++ b/pharmsol-dsl/src/analyze.rs
@@ -40,6 +40,8 @@ const RESERVED_NAMES: &[&str] = &[
     "cos",
     "tan",
     "sqrt",
+    "t",
+    "time",
 ];
 
 #[derive(Default)]
@@ -1235,6 +1237,15 @@ impl<'a> Analyzer<'a> {
             return Ok(AnalyzedExpr {
                 kind: AnalyzedExprKind::Symbol(symbol),
                 ty,
+                constant: None,
+                span,
+            });
+        }
+
+        if name.text == "t" || name.text == "time" {
+            return Ok(AnalyzedExpr {
+                kind: AnalyzedExprKind::Time,
+                ty: ValueType::Real,
                 constant: None,
                 span,
             });
@@ -3392,6 +3403,161 @@ model broken {
     }
 
     #[test]
+    fn t_resolves_to_the_time_expression() {
+        let src = r#"
+model uses_time {
+    kind ode
+    parameters { ke }
+    states { central }
+    dynamics {
+        ddt(central) = -ke * central * t
+    }
+    outputs {
+        cp = central * t
+    }
+}
+"#;
+        let model = parse_model(src).expect("model parses");
+        let analyzed = analyze_model(&model).expect("model using `t` analyzes");
+
+        let dynamics = analyzed.dynamics.as_ref().expect("dynamics block exists");
+        let assign = &dynamics.statements[0];
+        let AnalyzedStmtKind::Assign(assign) = &assign.kind else {
+            panic!("expected an assignment statement");
+        };
+        assert!(expr_contains_time(&assign.value));
+    }
+
+    #[test]
+    fn time_is_an_alias_for_t() {
+        let src = r#"
+model uses_time_alias {
+    kind ode
+    parameters { ke }
+    states { central }
+    dynamics {
+        ddt(central) = -ke * central * time
+    }
+    outputs {
+        cp = central * time
+    }
+}
+"#;
+        let model = parse_model(src).expect("model parses");
+        let analyzed = analyze_model(&model).expect("model using `time` analyzes");
+
+        let dynamics = analyzed.dynamics.as_ref().expect("dynamics block exists");
+        let assign = &dynamics.statements[0];
+        let AnalyzedStmtKind::Assign(assign) = &assign.kind else {
+            panic!("expected an assignment statement");
+        };
+        assert!(expr_contains_time(&assign.value));
+    }
+
+    fn expr_contains_time(expr: &AnalyzedExpr) -> bool {
+        match &expr.kind {
+            AnalyzedExprKind::Time => true,
+            AnalyzedExprKind::Unary { expr, .. } => expr_contains_time(expr),
+            AnalyzedExprKind::Binary { lhs, rhs, .. } => {
+                expr_contains_time(lhs) || expr_contains_time(rhs)
+            }
+            AnalyzedExprKind::Call { args, .. } => args.iter().any(expr_contains_time),
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn t_cannot_be_used_as_a_declared_symbol_name() {
+        let src = r#"
+model broken {
+    kind ode
+    parameters { t }
+    states { central }
+    dynamics {
+        ddt(central) = 0
+    }
+    outputs {
+        cp = central
+    }
+}
+"#;
+        let model = parse_model(src).expect("model parses");
+        let err = analyze_model(&model).expect_err("reserved name `t` must fail");
+
+        assert!(err
+            .render(src)
+            .contains("`t` is reserved by the DSL and cannot be used as a symbol name"));
+    }
+
+    #[test]
+    fn time_cannot_be_used_as_a_declared_symbol_name() {
+        let src = r#"
+model broken {
+    kind ode
+    parameters { time }
+    states { central }
+    dynamics {
+        ddt(central) = 0
+    }
+    outputs {
+        cp = central
+    }
+}
+"#;
+        let model = parse_model(src).expect("model parses");
+        let err = analyze_model(&model).expect_err("reserved name `time` must fail");
+
+        assert!(err
+            .render(src)
+            .contains("`time` is reserved by the DSL and cannot be used as a symbol name"));
+    }
+
+    #[test]
+    fn t_cannot_be_used_as_a_declared_state_name() {
+        let src = r#"
+model broken {
+    kind ode
+    states { t }
+    dynamics {
+        ddt(t) = 0
+    }
+    outputs {
+        cp = t
+    }
+}
+"#;
+        let model = parse_model(src).expect("model parses");
+        let err = analyze_model(&model).expect_err("reserved name `t` must fail as a state name");
+
+        assert!(err
+            .render(src)
+            .contains("`t` is reserved by the DSL and cannot be used as a symbol name"));
+    }
+
+    #[test]
+    fn time_cannot_be_used_as_a_declared_state_name() {
+        let src = r#"
+model broken {
+    kind ode
+    states { time }
+    dynamics {
+        ddt(time) = 0
+    }
+    outputs {
+        cp = time
+    }
+}
+"#;
+        let model = parse_model(src).expect("model parses");
+        let err =
+            analyze_model(&model).expect_err("reserved name `time` must fail as a state name");
+
+        assert!(err
+            .render(src)
+            .contains("`time` is reserved by the DSL and cannot be used as a symbol name"));
+    }
+
+    #[test]
     fn duplicate_constant_points_to_first_declaration() {
         let src = r#"
 model broken {
@@ -3697,6 +3863,7 @@ model broken {
                 state_place_signature(model, place),
                 expr.ty
             ),
+            AnalyzedExprKind::Time => format!("time:{:?}", expr.ty),
             AnalyzedExprKind::Unary { op, expr: inner } => {
                 format!("un:{op:?}:{}", expr_signature(model, inner))
             }

--- a/pharmsol-dsl/src/analyze.rs
+++ b/pharmsol-dsl/src/analyze.rs
@@ -3454,6 +3454,79 @@ model uses_time_alias {
         assert!(expr_contains_time(&assign.value));
     }
 
+    #[test]
+    fn t_can_be_used_in_a_derived_variable_consumed_by_dynamics() {
+        let src = r#"
+model uses_time_via_derive {
+    kind ode
+    parameters { ke }
+    states { central }
+    derive {
+        ke_t = ke + 0.0 * t
+    }
+    dynamics {
+        ddt(central) = -ke_t * central
+    }
+    outputs {
+        cp = central
+    }
+}
+"#;
+        let model = parse_model(src).expect("model parses");
+        let analyzed = analyze_model(&model).expect("model using `t` in a derive block analyzes");
+
+        // `t` does not appear directly in the dynamics equation...
+        let dynamics = analyzed.dynamics.as_ref().expect("dynamics block exists");
+        let AnalyzedStmtKind::Assign(dynamics_assign) = &dynamics.statements[0].kind else {
+            panic!("expected an assignment statement");
+        };
+        assert!(!expr_contains_time(&dynamics_assign.value));
+
+        // ...it is used one level removed, inside the `derive` block's secondary equation.
+        let derive = analyzed.derive.as_ref().expect("derive block exists");
+        let AnalyzedStmtKind::Assign(derive_assign) = &derive.statements[0].kind else {
+            panic!("expected an assignment statement");
+        };
+        assert!(expr_contains_time(&derive_assign.value));
+    }
+
+    #[test]
+    fn time_can_be_used_in_a_derived_variable_consumed_by_outputs() {
+        let src = r#"
+model uses_time_alias_via_derive {
+    kind ode
+    parameters { ke }
+    states { central }
+    derive {
+        elapsed_penalty = 1.0 + 0.0 * time
+    }
+    dynamics {
+        ddt(central) = -ke * central
+    }
+    outputs {
+        cp = central * elapsed_penalty
+    }
+}
+"#;
+        let model = parse_model(src).expect("model parses");
+        let analyzed =
+            analyze_model(&model).expect("model using `time` in a derive block analyzes");
+
+        // `time` does not appear directly in the outputs equation...
+        let outputs = &analyzed.outputs_block;
+        let AnalyzedStmtKind::Assign(outputs_assign) = &outputs.statements[0].kind else {
+            panic!("expected an assignment statement");
+        };
+        assert!(!expr_contains_time(&outputs_assign.value));
+
+        // ...it is used one level removed, inside the `derive` block's secondary equation.
+        let derive = analyzed.derive.as_ref().expect("derive block exists");
+        let AnalyzedStmtKind::Assign(derive_assign) = &derive.statements[0].kind else {
+            panic!("expected an assignment statement");
+        };
+        assert!(expr_contains_time(&derive_assign.value));
+    }
+
     fn expr_contains_time(expr: &AnalyzedExpr) -> bool {
         match &expr.kind {
             AnalyzedExprKind::Time => true,

--- a/pharmsol-dsl/src/execution.rs
+++ b/pharmsol-dsl/src/execution.rs
@@ -355,6 +355,7 @@ pub enum ExecutionExprKind {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ExecutionLoad {
+    Time,
     Parameter(usize),
     Covariate(usize),
     State(ExecutionStateRef),
@@ -1161,6 +1162,7 @@ impl<'a> ModelCompiler<'a> {
             AnalyzedExprKind::StateValue(place) => ExecutionExprKind::Load(ExecutionLoad::State(
                 self.compile_state_ref(place, locals)?,
             )),
+            AnalyzedExprKind::Time => ExecutionExprKind::Load(ExecutionLoad::Time),
             AnalyzedExprKind::Unary { op, expr } => ExecutionExprKind::Unary {
                 op: *op,
                 expr: Box::new(self.compile_expr(expr, locals)?),

--- a/src/dsl/jit.rs
+++ b/src/dsl/jit.rs
@@ -191,7 +191,7 @@ struct ExternRefs {
 
 #[derive(Clone, Copy)]
 struct FunctionArgs {
-    _time: Value,
+    time: Value,
     states: Value,
     params: Value,
     covariates: Value,
@@ -444,7 +444,7 @@ fn emit_statement_function(
 
     let params = builder.block_params(entry);
     let args = FunctionArgs {
-        _time: params[0],
+        time: params[0],
         states: params[1],
         params: params[2],
         covariates: params[3],
@@ -737,6 +737,7 @@ fn lower_load(
     span: Span,
 ) -> Result<LoweredValue, JitCompileError> {
     let value = match load {
+        ExecutionLoad::Time => env.args.time,
         ExecutionLoad::Parameter(index) => load_fixed(builder, env.args.params, *index, ty),
         ExecutionLoad::Covariate(index) => load_fixed(builder, env.args.covariates, *index, ty),
         ExecutionLoad::Derived(index) => load_fixed(builder, env.args.derived, *index, ty),

--- a/src/dsl/rust_backend.rs
+++ b/src/dsl/rust_backend.rs
@@ -260,6 +260,7 @@ fn emit_expr(expr: &ExecutionExpr) -> Result<RenderedExpr, String> {
 
 fn emit_load(load: &ExecutionLoad, ty: ValueType) -> Result<String, String> {
     let raw = match load {
+        ExecutionLoad::Time => "t".to_string(),
         ExecutionLoad::Parameter(index) => format!("load_f64(params, {index})"),
         ExecutionLoad::Covariate(index) => format!("load_f64(covariates, {index})"),
         ExecutionLoad::Derived(index) => format!("load_f64(derived, {index})"),

--- a/src/dsl/wasm_direct_emitter.rs
+++ b/src/dsl/wasm_direct_emitter.rs
@@ -35,6 +35,7 @@ const BINARY_REAL_IMPORT_TYPE: u32 = 5;
 
 const HEAP_PTR_GLOBAL: u32 = 0;
 
+const KERNEL_PARAM_TIME: u32 = 0;
 const KERNEL_PARAM_STATES: u32 = 1;
 const KERNEL_PARAM_PARAMS: u32 = 2;
 const KERNEL_PARAM_COVARIATES: u32 = 3;
@@ -931,6 +932,10 @@ fn emit_load(
     function: &mut Function,
 ) -> Result<(), WasmError> {
     match load {
+        ExecutionLoad::Time => {
+            function.instruction(&Instruction::LocalGet(KERNEL_PARAM_TIME));
+            emit_cast_stack(ValueType::Real, target_ty, function, state.model_name)
+        }
         ExecutionLoad::Parameter(index) => emit_dense_load(
             function,
             KERNEL_PARAM_PARAMS,

--- a/tests/dsl_time_keyword.rs
+++ b/tests/dsl_time_keyword.rs
@@ -1,0 +1,100 @@
+//! Verifies that the DSL's `t` keyword (and its `time` alias) resolves to the
+//! current simulation time and flows correctly through analysis, execution
+//! compilation, and the JIT / WASM backends.
+
+#![cfg(any(feature = "dsl-jit", feature = "dsl-wasm"))]
+
+use pharmsol::dsl::{compile_module_source_to_runtime, RuntimeCompilationTarget};
+use pharmsol::{prelude::*, Parameters};
+
+const MODEL_SOURCE: &str = r#"
+name = time_probe
+kind = ode
+
+params = ke
+states = central
+outputs = cp, time_echo
+
+infusion(iv) -> central
+
+dx(central) = -ke * central
+
+out(cp) = central
+out(time_echo) = t
+"#;
+
+const MODEL_SOURCE_TIME_ALIAS: &str = r#"
+name = time_probe
+kind = ode
+
+params = ke
+states = central
+outputs = cp, time_echo
+
+infusion(iv) -> central
+
+dx(central) = -ke * central
+
+out(cp) = central
+out(time_echo) = time
+"#;
+
+fn assert_time_echo_matches_observation_times(
+    model: &pharmsol::dsl::CompiledRuntimeModel,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let support_point = Parameters::with_model(model, [("ke", 1.0)])?;
+
+    let subject = Subject::builder("time_probe")
+        .infusion(0.0, 100.0, "iv", 1.0)
+        .missing_observation(0.5, "time_echo")
+        .missing_observation(1.0, "time_echo")
+        .missing_observation(2.5, "time_echo")
+        .missing_observation(4.0, "time_echo")
+        .build();
+
+    let predictions = model
+        .estimate_predictions(&subject, &support_point)?
+        .into_subject()
+        .ok_or("expected subject predictions")?;
+
+    let mut checked = 0;
+    for prediction in predictions.predictions() {
+        assert!(
+            (prediction.time() - prediction.prediction()).abs() < 1e-6,
+            "expected `t` to equal the observation time, got t={} prediction={}",
+            prediction.time(),
+            prediction.prediction()
+        );
+        checked += 1;
+    }
+    assert_eq!(
+        checked, 4,
+        "expected all four `time_echo` observations to be checked"
+    );
+
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "dsl-jit")]
+fn t_keyword_reflects_the_current_simulation_time_jit() -> Result<(), Box<dyn std::error::Error>> {
+    let model = compile_module_source_to_runtime(
+        MODEL_SOURCE,
+        Some("time_probe"),
+        RuntimeCompilationTarget::Jit,
+        |_, _| {},
+    )?;
+    assert_time_echo_matches_observation_times(&model)
+}
+
+#[test]
+#[cfg(feature = "dsl-wasm")]
+fn t_keyword_reflects_the_current_simulation_time_wasm() -> Result<(), Box<dyn std::error::Error>> {
+    let model = compile_module_source_to_runtime(
+        MODEL_SOURCE,
+        Some("time_probe"),
+        RuntimeCompilationTarget::Wasm,
+        |_, _| {},
+    )?;
+    assert_time_echo_matches_observation_times(&model)
+}


### PR DESCRIPTION
Time can now be referred to, accessible using either `t` or `time`.
A compile error occurs if either of those are declared as parameters or states.