### PR TITLE
fix: Force the solver to stop at the infusions end time

### DIFF
--- a/src/dsl/jit.rs
+++ b/src/dsl/jit.rs
@@ -1449,6 +1449,7 @@ out(cp) = central / v ~ continuous()
             .observation(2.0, 0.0, "cp")
             .observation(6.0, 0.0, "cp")
             .observation(7.0, 0.0, "cp")
+            .observation(8.0, 0.0, "cp")
             .observation(9.0, 0.0, "cp")
             .build();
 
@@ -1460,6 +1461,7 @@ out(cp) = central / v ~ continuous()
             .observation(2.0, 0.0, 0)
             .observation(6.0, 0.0, 0)
             .observation(7.0, 0.0, 0)
+            .observation(8.0, 0.0, 0)
             .observation(9.0, 0.0, 0)
             .build();
 

--- a/src/dsl/native.rs
+++ b/src/dsl/native.rs
@@ -1133,6 +1133,8 @@ impl NativeOdeModel {
         self.shared.validate_support_point(support_point)?;
         let mut output = SubjectPredictions::default();
         let support_vector: V = DVector::from_vec(support_point.to_vec()).into();
+        // Scratch for refreshing the solver's derivative at infusion boundaries.
+        let mut dy_scratch = V::zeros(self.shared.info.state_len, NalgebraContext::new());
 
         for occasion in subject.occasions() {
             let mut events = self.shared.resolve_events(occasion)?;
@@ -1253,6 +1255,7 @@ impl NativeOdeModel {
                         support_point,
                         occasion.covariates(),
                         infusions.as_slice(),
+                        &mut dy_scratch,
                         &mut output,
                         &session,
                         &function_error,
@@ -1287,6 +1290,7 @@ impl NativeOdeModel {
         support_point: &[f64],
         covariates: &Covariates,
         infusions: &[Infusion],
+        dy_scratch: &mut V,
         output: &mut SubjectPredictions,
         session: &RefCell<Box<dyn FunctionSession + '_>>,
         function_error: &RefCell<Option<PharmsolError>>,
@@ -1295,7 +1299,25 @@ impl NativeOdeModel {
         F: Fn(&V, &V, f64, &mut V, &V, &V, &Covariates) + 'a,
         S: OdeSolverMethod<'a, PMProblem<'a, F>>,
     {
-        for (index, event) in events.iter().enumerate() {
+        // Mirror the closure-based ODE event loop: stop at every infusion
+        // start and end boundary in addition to subject events, using the
+        // left-continuous rate while integrating toward a boundary and the
+        // right-continuous rate after reaching it. This keeps the JIT
+        // implementation numerically consistent with the reference [`ODE`]
+        // path (see `ode::run_events`).
+        let infusion_boundary_times = solver.problem().eqn.infusion_boundary_times();
+        let mut infusion_boundary_cursor = 0usize;
+        let mut index = 0usize;
+        // Set when the previous stop was an infusion boundary: the solver must
+        // be restarted before the first step of the next segment (the RHS is
+        // discontinuous at the boundary). Deferred until `set_stop_time`
+        // succeeds so a stop that is already reached does not trigger a
+        // restart for a zero-length segment.
+        let mut pending_reinit = false;
+        while index < events.len() {
+            let event = &events[index];
+            let next_event = events.get(index + 1);
+
             match event {
                 Event::Bolus(bolus) => {
                     let input = bolus.input_index().ok_or_else(|| {
@@ -1327,44 +1349,113 @@ impl NativeOdeModel {
                 }
             }
 
-            if let Some(next_event) = events.get(index + 1) {
-                if event.time() == next_event.time() {
-                    continue;
-                }
+            // Advance to the next event time if it exists.
+            if let Some(next_event) = next_event {
+                let next_event_time = next_event.time();
+                while next_event_time > solver.state().t {
+                    while infusion_boundary_cursor < infusion_boundary_times.len()
+                        && infusion_boundary_times[infusion_boundary_cursor] <= solver.state().t
+                    {
+                        infusion_boundary_cursor += 1;
+                    }
 
-                match solver.set_stop_time(next_event.time()) {
-                    Ok(_) => loop {
-                        match solver.step() {
-                            Ok(_) if function_error.borrow().is_some() => {
-                                return Err(function_error.borrow_mut().take().unwrap());
+                    let (stop_time, is_infusion_boundary) = if let Some(stop_time) =
+                        infusion_boundary_times.get(infusion_boundary_cursor)
+                    {
+                        if *stop_time <= next_event_time {
+                            infusion_boundary_cursor += 1;
+                            (*stop_time, true)
+                        } else {
+                            (next_event_time, false)
+                        }
+                    } else {
+                        (next_event_time, false)
+                    };
+
+                    solver
+                        .problem()
+                        .eqn
+                        .set_left_continuity_time(if is_infusion_boundary {
+                            Some(stop_time)
+                        } else {
+                            None
+                        });
+
+                    match solver.set_stop_time(stop_time) {
+                        Ok(_) => {
+                            if pending_reinit {
+                                crate::simulator::equation::ode::reinitialize_at_boundary(
+                                    solver, dy_scratch,
+                                );
+                                pending_reinit = false;
                             }
-                            Ok(OdeSolverStopReason::InternalTimestep) => continue,
-                            Ok(OdeSolverStopReason::TstopReached) => break,
-                            Ok(OdeSolverStopReason::RootFound(_, _)) => {
-                                return Err(PharmsolError::OtherError(format!(
-                                    "solver stopped at an unexpected root at t = {:.4} \
-                                     (root finding is not configured)",
-                                    next_event.time()
-                                )));
-                            }
-                            Err(err) => {
-                                return Err(PharmsolError::from_solver_error(
-                                    err,
-                                    next_event.time(),
-                                ));
+                            loop {
+                                match solver.step() {
+                                    Ok(_) if function_error.borrow().is_some() => {
+                                        return Err(function_error.borrow_mut().take().unwrap());
+                                    }
+                                    Ok(OdeSolverStopReason::InternalTimestep) => continue,
+                                    Ok(OdeSolverStopReason::TstopReached) => {
+                                        solver.problem().eqn.set_left_continuity_time(None);
+                                        if is_infusion_boundary {
+                                            pending_reinit = true;
+                                        }
+                                        break;
+                                    }
+                                    Ok(OdeSolverStopReason::RootFound(_, _)) => {
+                                        return Err(PharmsolError::OtherError(format!(
+                                            "solver stopped at an unexpected root at t = {:.4} \
+                                             (root finding is not configured)",
+                                            stop_time
+                                        )));
+                                    }
+                                    Err(err) => {
+                                        return Err(PharmsolError::from_solver_error(
+                                            err, stop_time,
+                                        ));
+                                    }
+                                }
                             }
                         }
-                    },
-                    Err(diffsol::error::DiffsolError::OdeSolverError(
-                        OdeSolverError::StopTimeAtCurrentTime,
-                    )) => continue,
-                    Err(err) => {
-                        return Err(PharmsolError::from_solver_error(err, next_event.time()));
+                        Err(diffsol::error::DiffsolError::OdeSolverError(
+                            OdeSolverError::StopTimeAtCurrentTime,
+                        )) => {
+                            solver.problem().eqn.set_left_continuity_time(None);
+                            let state_t = solver.state().t;
+                            let stop_reached = stop_time == state_t
+                                || stop_time == state_t.next_up()
+                                || stop_time == state_t.next_down();
+
+                            if stop_reached {
+                                if is_infusion_boundary {
+                                    pending_reinit = true;
+                                }
+                                // The requested stop is the current time (within
+                                // one ULP). If it is an infusion boundary before
+                                // the next subject event, keep integrating toward
+                                // the event; break only when the reached stop is
+                                // the event time itself.
+                                if stop_time < next_event_time {
+                                    continue;
+                                }
+                                break;
+                            }
+                            return Err(PharmsolError::from_solver_error(
+                                diffsol::error::DiffsolError::OdeSolverError(
+                                    OdeSolverError::StopTimeAtCurrentTime,
+                                ),
+                                stop_time,
+                            ));
+                        }
+                        Err(err) => {
+                            solver.problem().eqn.set_left_continuity_time(None);
+                            return Err(PharmsolError::from_solver_error(err, stop_time));
+                        }
                     }
                 }
             }
+            index += 1;
         }
-
         Ok(())
     }
 }

--- a/src/simulator/equation/ode/closure.rs
+++ b/src/simulator/equation/ode/closure.rs
@@ -3,7 +3,10 @@ use diffsol::{
     ConstantOp, LinearOp, MatrixCommon, NalgebraContext, NalgebraMat, NonLinearOp,
     NonLinearOpJacobian, OdeEquations, OdeEquationsRef, Op, UnitCallable, Vector,
 };
-use std::{cell::RefCell, cmp::Ordering};
+use std::{
+    cell::{Cell, RefCell},
+    cmp::Ordering,
+};
 type M = NalgebraMat<f64>;
 type V = <M as MatrixCommon>::V;
 type C = <M as MatrixCommon>::C;
@@ -37,7 +40,43 @@ impl InfusionTrack {
         }
     }
 
-    fn rate_at(&self, time: f64) -> f64 {
+    fn rate_at(&self, time: f64, left_continuity_time: Option<f64>) -> f64 {
+        if let Some(left_continuity_time) = left_continuity_time {
+            if left_continuity_time == time {
+                return self.rate_at_left(time);
+            }
+        }
+
+        self.rate_at_right(time)
+    }
+
+    fn rate_at_left(&self, time: f64) -> f64 {
+        if self.event_times.is_empty() {
+            return 0.0;
+        }
+
+        let event_search = self
+            .event_times
+            .binary_search_by(|probe| probe.partial_cmp(&time).unwrap_or(Ordering::Less));
+
+        match event_search {
+            Ok(mut idx) => {
+                while idx > 0 && self.event_times[idx - 1] == time {
+                    idx -= 1;
+                }
+
+                if idx == 0 {
+                    0.0
+                } else {
+                    self.cumulative_rates[idx - 1]
+                }
+            }
+            Err(0) => 0.0,
+            Err(idx) => self.cumulative_rates[idx - 1],
+        }
+    }
+
+    fn rate_at_right(&self, time: f64) -> f64 {
         if self.event_times.is_empty() {
             return 0.0;
         }
@@ -63,6 +102,8 @@ impl InfusionTrack {
 #[derive(Debug, Clone, Default)]
 struct InfusionSchedule {
     tracks: Vec<InfusionTrack>,
+    discontinuity_times: Vec<f64>,
+    left_continuity_time: Cell<Option<f64>>,
 }
 
 impl InfusionSchedule {
@@ -71,11 +112,16 @@ impl InfusionSchedule {
         I: IntoIterator<Item = &'a Infusion>,
     {
         if ndrugs == 0 {
-            return Ok(Self { tracks: Vec::new() });
+            return Ok(Self {
+                tracks: Vec::new(),
+                discontinuity_times: Vec::new(),
+                left_continuity_time: Cell::new(None),
+            });
         }
 
         let mut per_input: Vec<Vec<(f64, f64)>> = vec![Vec::new(); ndrugs];
         let mut saw_infusion = false;
+        let mut discontinuity_times = Vec::new();
         for infusion in infusions {
             saw_infusion = true;
             if infusion.duration() <= 0.0 {
@@ -90,12 +136,22 @@ impl InfusionSchedule {
             }
 
             let rate = infusion.amount() / infusion.duration();
+            let end = infusion.time() + infusion.duration();
+
             per_input[input].push((infusion.time(), rate));
-            per_input[input].push((infusion.time() + infusion.duration(), -rate));
+            per_input[input].push((end, -rate));
+            discontinuity_times.push(end);
         }
 
+        discontinuity_times.sort_by(|a, b| a.total_cmp(b));
+        discontinuity_times.dedup_by(|a, b| a == b);
+
         if !saw_infusion {
-            return Ok(Self { tracks: Vec::new() });
+            return Ok(Self {
+                tracks: Vec::new(),
+                discontinuity_times,
+                left_continuity_time: Cell::new(None),
+            });
         }
 
         let tracks = per_input
@@ -110,13 +166,26 @@ impl InfusionSchedule {
             })
             .collect();
 
-        Ok(Self { tracks })
+        Ok(Self {
+            tracks,
+            discontinuity_times,
+            left_continuity_time: Cell::new(None),
+        })
+    }
+
+    fn set_left_continuity_time(&self, time: Option<f64>) {
+        self.left_continuity_time.set(time);
+    }
+
+    fn infusion_end_times(&self) -> &[f64] {
+        &self.discontinuity_times
     }
 
     fn fill_rate_vector(&self, time: f64, rateiv: &mut V) {
+        let left_continuity_time = self.left_continuity_time.get();
         rateiv.fill(0.0);
         for track in &self.tracks {
-            let rate = track.rate_at(time);
+            let rate = track.rate_at(time, left_continuity_time);
             if rate != 0.0 {
                 rateiv[track.input] = rate;
             }
@@ -336,6 +405,14 @@ impl<'a, F> PMProblem<'a, F>
 where
     F: Fn(&V, &V, T, &mut V, &V, &V, &Covariates) + 'a,
 {
+    pub(crate) fn set_left_continuity_time(&self, time: Option<f64>) {
+        self.infusion_schedule.set_left_continuity_time(time);
+    }
+
+    pub(crate) fn infusion_end_times(&self) -> &[f64] {
+        self.infusion_schedule.infusion_end_times()
+    }
+
     /// Creates a new PMProblem with a pre-converted parameter vector.
     /// This avoids an allocation when the caller already has a V representation.
     #[allow(clippy::too_many_arguments)]

--- a/src/simulator/equation/ode/closure.rs
+++ b/src/simulator/equation/ode/closure.rs
@@ -102,7 +102,7 @@ impl InfusionTrack {
 #[derive(Debug, Clone, Default)]
 struct InfusionSchedule {
     tracks: Vec<InfusionTrack>,
-    discontinuity_times: Vec<f64>,
+    boundary_times: Vec<f64>,
     left_continuity_time: Cell<Option<f64>>,
 }
 
@@ -114,14 +114,14 @@ impl InfusionSchedule {
         if ndrugs == 0 {
             return Ok(Self {
                 tracks: Vec::new(),
-                discontinuity_times: Vec::new(),
+                boundary_times: Vec::new(),
                 left_continuity_time: Cell::new(None),
             });
         }
 
         let mut per_input: Vec<Vec<(f64, f64)>> = vec![Vec::new(); ndrugs];
         let mut saw_infusion = false;
-        let mut discontinuity_times = Vec::new();
+        let mut boundary_times = Vec::new();
         for infusion in infusions {
             saw_infusion = true;
             if infusion.duration() <= 0.0 {
@@ -140,16 +140,17 @@ impl InfusionSchedule {
 
             per_input[input].push((infusion.time(), rate));
             per_input[input].push((end, -rate));
-            discontinuity_times.push(end);
+            boundary_times.push(infusion.time());
+            boundary_times.push(end);
         }
 
-        discontinuity_times.sort_by(|a, b| a.total_cmp(b));
-        discontinuity_times.dedup_by(|a, b| a == b);
+        boundary_times.sort_by(|a, b| a.total_cmp(b));
+        boundary_times.dedup();
 
         if !saw_infusion {
             return Ok(Self {
                 tracks: Vec::new(),
-                discontinuity_times,
+                boundary_times,
                 left_continuity_time: Cell::new(None),
             });
         }
@@ -168,7 +169,7 @@ impl InfusionSchedule {
 
         Ok(Self {
             tracks,
-            discontinuity_times,
+            boundary_times,
             left_continuity_time: Cell::new(None),
         })
     }
@@ -177,8 +178,8 @@ impl InfusionSchedule {
         self.left_continuity_time.set(time);
     }
 
-    fn infusion_end_times(&self) -> &[f64] {
-        &self.discontinuity_times
+    fn infusion_boundary_times(&self) -> &[f64] {
+        &self.boundary_times
     }
 
     fn fill_rate_vector(&self, time: f64, rateiv: &mut V) {
@@ -409,8 +410,28 @@ where
         self.infusion_schedule.set_left_continuity_time(time);
     }
 
-    pub(crate) fn infusion_end_times(&self) -> &[f64] {
-        self.infusion_schedule.infusion_end_times()
+    pub(crate) fn infusion_boundary_times(&self) -> &[f64] {
+        self.infusion_schedule.infusion_boundary_times()
+    }
+
+    /// Evaluate the full RHS (including the currently scheduled infusion
+    /// rates) at time `t` into `dx`.
+    ///
+    /// Used at infusion boundaries to refresh the solver's stored derivative
+    /// against the post-boundary (right-continuous) RHS, so a solver restart
+    /// predicts with the new dynamics instead of the pre-boundary ones.
+    pub(crate) fn refresh_state_derivative(&self, t: f64, x: &V, dx: &mut V) {
+        let mut rateiv = self.rateiv_buffer.borrow_mut();
+        self.infusion_schedule.fill_rate_vector(t, &mut rateiv);
+        (self.func)(
+            x,
+            &self.p_as_v,
+            t,
+            dx,
+            &self.zero_bolus,
+            &rateiv,
+            self.covariates,
+        );
     }
 
     /// Creates a new PMProblem with a pre-converted parameter vector.

--- a/src/simulator/equation/ode/mod.rs
+++ b/src/simulator/equation/ode/mod.rs
@@ -544,6 +544,28 @@ impl EquationPriv for ODE {
 }
 
 impl ODE {
+    fn infusion_end_times(events: &[Event]) -> Vec<f64> {
+        let mut stops: Vec<f64> = events
+            .iter()
+            .filter_map(|event| {
+                let infusion = match event {
+                    Event::Infusion(infusion) => infusion,
+                    _ => return None,
+                };
+                let start = infusion.time();
+                let end = start + infusion.duration();
+                if end.is_finite() && end > start {
+                    Some(end)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        stops.sort_by(|a, b| a.total_cmp(b));
+        stops.dedup_by(|a, b| a == b);
+        stops
+    }
+
     /// Generic event-loop runner, parameterized over the concrete solver type.
     #[allow(clippy::too_many_arguments)]
     fn run_events<'a, F, S>(
@@ -562,11 +584,14 @@ impl ODE {
         likelihood: &mut Vec<f64>,
         output: &mut SubjectPredictions,
     ) -> Result<(), PharmsolError>
-    where
+        where
         F: Fn(&V, &V, f64, &mut V, &V, &V, &Covariates) + 'a,
         S: OdeSolverMethod<'a, PMProblem<'a, F>>,
     {
-        for (index, event) in events.iter().enumerate() {
+        let infusion_stop_times = Self::infusion_end_times(events);
+        let mut index = 0usize;
+        while index < events.len() {
+            let event = &events[index];
             let next_event = events.get(index + 1);
 
             match event {
@@ -645,8 +670,16 @@ impl ODE {
 
             // Advance to the next event time if it exists
             if let Some(next_event) = next_event {
-                if !event.time().eq(&next_event.time()) {
-                    match solver.set_stop_time(next_event.time()) {
+                while solver.state().t < next_event.time() {
+                    let mut stop_time = next_event.time();
+                    for stop in &infusion_stop_times {
+                        if stop > &solver.state().t && stop < &stop_time {
+                            stop_time = *stop;
+                            break;
+                        }
+                    }
+
+                    match solver.set_stop_time(stop_time) {
                         Ok(_) => loop {
                             match solver.step() {
                                 Ok(OdeSolverStopReason::InternalTimestep) => continue,
@@ -655,13 +688,12 @@ impl ODE {
                                     return Err(PharmsolError::OtherError(format!(
                                         "solver stopped at an unexpected root at t = {:.4} \
                                          (root finding is not configured)",
-                                        next_event.time()
+                                        stop_time
                                     )));
                                 }
                                 Err(err) => {
                                     return Err(PharmsolError::from_solver_error(
-                                        err,
-                                        next_event.time(),
+                                        err, stop_time,
                                     ));
                                 }
                             }
@@ -669,14 +701,15 @@ impl ODE {
                         Err(diffsol::error::DiffsolError::OdeSolverError(
                             OdeSolverError::StopTimeAtCurrentTime,
                         )) => {
-                            continue;
+                            break;
                         }
                         Err(err) => {
-                            return Err(PharmsolError::from_solver_error(err, next_event.time()));
+                            return Err(PharmsolError::from_solver_error(err, stop_time));
                         }
                     }
                 }
             }
+            index += 1;
         }
         Ok(())
     }

--- a/src/simulator/equation/ode/mod.rs
+++ b/src/simulator/equation/ode/mod.rs
@@ -584,7 +584,7 @@ impl ODE {
         likelihood: &mut Vec<f64>,
         output: &mut SubjectPredictions,
     ) -> Result<(), PharmsolError>
-        where
+    where
         F: Fn(&V, &V, f64, &mut V, &V, &V, &Covariates) + 'a,
         S: OdeSolverMethod<'a, PMProblem<'a, F>>,
     {
@@ -692,9 +692,7 @@ impl ODE {
                                     )));
                                 }
                                 Err(err) => {
-                                    return Err(PharmsolError::from_solver_error(
-                                        err, stop_time,
-                                    ));
+                                    return Err(PharmsolError::from_solver_error(err, stop_time));
                                 }
                             }
                         },

--- a/src/simulator/equation/ode/mod.rs
+++ b/src/simulator/equation/ode/mod.rs
@@ -588,6 +588,7 @@ impl ODE {
         F: Fn(&V, &V, f64, &mut V, &V, &V, &Covariates) + 'a,
         S: OdeSolverMethod<'a, PMProblem<'a, F>>,
     {
+        const STOP_TIME_EPS: f64 = 1e-12;
         let infusion_stop_times = Self::infusion_end_times(events);
         let mut index = 0usize;
         while index < events.len() {
@@ -670,10 +671,13 @@ impl ODE {
 
             // Advance to the next event time if it exists
             if let Some(next_event) = next_event {
-                while solver.state().t < next_event.time() {
+                while (next_event.time() - solver.state().t) > STOP_TIME_EPS {
                     let mut stop_time = next_event.time();
+                    let current_t = solver.state().t;
                     for stop in &infusion_stop_times {
-                        if stop > &solver.state().t && stop < &stop_time {
+                        if stop > &(current_t + STOP_TIME_EPS)
+                            && stop < &(stop_time - STOP_TIME_EPS)
+                        {
                             stop_time = *stop;
                             break;
                         }
@@ -683,7 +687,9 @@ impl ODE {
                         Ok(_) => loop {
                             match solver.step() {
                                 Ok(OdeSolverStopReason::InternalTimestep) => continue,
-                                Ok(OdeSolverStopReason::TstopReached) => break,
+                                Ok(OdeSolverStopReason::TstopReached) => {
+                                    break;
+                                }
                                 Ok(OdeSolverStopReason::RootFound(_, _)) => {
                                     return Err(PharmsolError::OtherError(format!(
                                         "solver stopped at an unexpected root at t = {:.4} \
@@ -699,7 +705,25 @@ impl ODE {
                         Err(diffsol::error::DiffsolError::OdeSolverError(
                             OdeSolverError::StopTimeAtCurrentTime,
                         )) => {
-                            break;
+                            if (stop_time - solver.state().t).abs() <= STOP_TIME_EPS {
+                                {
+                                    let state = solver.state_mut();
+                                    if (stop_time - *state.t).abs() > STOP_TIME_EPS {
+                                        *state.t = stop_time;
+                                    }
+                                }
+
+                                if (next_event.time() - stop_time).abs() <= STOP_TIME_EPS {
+                                    break;
+                                }
+                                continue;
+                            }
+                            return Err(PharmsolError::from_solver_error(
+                                diffsol::error::DiffsolError::OdeSolverError(
+                                    OdeSolverError::StopTimeAtCurrentTime,
+                                ),
+                                stop_time,
+                            ));
                         }
                         Err(err) => {
                             return Err(PharmsolError::from_solver_error(err, stop_time));

--- a/src/simulator/equation/ode/mod.rs
+++ b/src/simulator/equation/ode/mod.rs
@@ -561,14 +561,7 @@ impl EquationPriv for ODE {
 ///   dynamics instead of the pre-boundary ones;
 /// - `state_mut` marks the state as modified so the next step restarts the
 ///   multi-step method at first order.
-///
-/// The first step is additionally capped just below `next_stop_time` (the
-/// stop the next segment is integrating toward): a restart step landing
-/// exactly on the next discontinuity inherits a Jacobian built for the
-/// pre-boundary order and can make the nonlinear solve oscillate, while a
-/// step that ends just before it converges cleanly (the error controller
-/// takes over from there).
-fn reinitialize_at_boundary<'a, F, S>(solver: &mut S, dy_scratch: &mut V, next_stop_time: f64)
+fn reinitialize_at_boundary<'a, F, S>(solver: &mut S, dy_scratch: &mut V)
 where
     F: Fn(&V, &V, f64, &mut V, &V, &V, &Covariates) + 'a,
     S: OdeSolverMethod<'a, PMProblem<'a, F>>,
@@ -586,7 +579,6 @@ where
     }
     let state = solver.state_mut();
     state.dy.copy_from(dy_scratch);
-    *state.h = (*state.h).min(0.9 * (next_stop_time - t).max(0.0));
 }
 
 impl ODE {
@@ -618,8 +610,9 @@ impl ODE {
         let mut index = 0usize;
         // Set when the previous stop was an infusion boundary: the solver must
         // be restarted before the first step of the next segment (the RHS is
-        // discontinuous at the boundary). Deferred until the next stop time is
-        // known so the first step can be capped below it.
+        // discontinuous at the boundary). Deferred until `set_stop_time`
+        // succeeds so a stop that is already reached does not trigger a
+        // restart for a zero-length segment.
         let mut pending_reinit = false;
         while index < events.len() {
             let event = &events[index];
@@ -722,11 +715,6 @@ impl ODE {
                         (next_event_time, false)
                     };
 
-                    if pending_reinit {
-                        reinitialize_at_boundary(solver, dy_scratch, stop_time);
-                        pending_reinit = false;
-                    }
-
                     solver
                         .problem()
                         .eqn
@@ -737,28 +725,36 @@ impl ODE {
                         });
 
                     match solver.set_stop_time(stop_time) {
-                        Ok(_) => loop {
-                            match solver.step() {
-                                Ok(OdeSolverStopReason::InternalTimestep) => continue,
-                                Ok(OdeSolverStopReason::TstopReached) => {
-                                    solver.problem().eqn.set_left_continuity_time(None);
-                                    if is_infusion_boundary {
-                                        pending_reinit = true;
+                        Ok(_) => {
+                            if pending_reinit {
+                                reinitialize_at_boundary(solver, dy_scratch);
+                                pending_reinit = false;
+                            }
+                            loop {
+                                match solver.step() {
+                                    Ok(OdeSolverStopReason::InternalTimestep) => continue,
+                                    Ok(OdeSolverStopReason::TstopReached) => {
+                                        solver.problem().eqn.set_left_continuity_time(None);
+                                        if is_infusion_boundary {
+                                            pending_reinit = true;
+                                        }
+                                        break;
                                     }
-                                    break;
-                                }
-                                Ok(OdeSolverStopReason::RootFound(_, _)) => {
-                                    return Err(PharmsolError::OtherError(format!(
-                                        "solver stopped at an unexpected root at t = {:.4} \
-                                         (root finding is not configured)",
-                                        stop_time
-                                    )));
-                                }
-                                Err(err) => {
-                                    return Err(PharmsolError::from_solver_error(err, stop_time));
+                                    Ok(OdeSolverStopReason::RootFound(_, _)) => {
+                                        return Err(PharmsolError::OtherError(format!(
+                                            "solver stopped at an unexpected root at t = {:.4} \
+                                             (root finding is not configured)",
+                                            stop_time
+                                        )));
+                                    }
+                                    Err(err) => {
+                                        return Err(PharmsolError::from_solver_error(
+                                            err, stop_time,
+                                        ));
+                                    }
                                 }
                             }
-                        },
+                        }
                         Err(diffsol::error::DiffsolError::OdeSolverError(
                             OdeSolverError::StopTimeAtCurrentTime,
                         )) => {
@@ -771,6 +767,17 @@ impl ODE {
                             if stop_reached {
                                 if is_infusion_boundary {
                                     pending_reinit = true;
+                                }
+                                // The requested stop is the current time (within
+                                // one ULP). If it is an infusion boundary before
+                                // the next subject event, keep integrating toward
+                                // the event; break only when the reached stop is
+                                // the event time itself. Breaking early would skip
+                                // the remaining interval and leave the solver
+                                // state at the boundary when the observation is
+                                // evaluated.
+                                if stop_time < next_event_time {
+                                    continue;
                                 }
                                 break;
                             }
@@ -1313,5 +1320,305 @@ mod tests {
         let predictions = run_infusions(&subject, OdeSolver::Bdf);
 
         assert_relative_eq!(predictions[0], 200.0, max_relative = 1e-4);
+    }
+
+    #[test]
+    fn ode_infusions_accepted_stop_before_event_keeps_integrating() {
+        // The infusion ends exactly one ULP after the observation at t = 10.
+        // After landing on the observation stop the solver is already within
+        // diffsol's round-off of the end boundary, so `set_stop_time` reports
+        // `StopTimeAtCurrentTime` and the loop accepts it through the
+        // same-ULP check. The reached boundary is *before* the observation at
+        // t = 20, so the event loop must keep integrating toward it; breaking
+        // early would evaluate the observation with the state frozen at the
+        // boundary and miss the exponential decay.
+        let subject = Subject::builder("accepted_stop_before_event")
+            .infusion(5.0, 100.0, "iv", 10.0_f64.next_up() - 5.0)
+            .observation(10.0, 0.0, "cp")
+            .observation(20.0, 0.0, "cp")
+            .build();
+
+        let ode = ODE::new(
+            |x: &V, _p: &V, _t: f64, dx: &mut V, _b: &V, rateiv: &V, _cov: &Covariates| {
+                dx[0] = rateiv[0] - 0.5 * x[0];
+            },
+            zero_lag,
+            unit_fa,
+            zero_init,
+            state_output,
+        )
+        .with_nstates(1)
+        .with_ndrugs(1)
+        .with_nout(1)
+        .with_solver(OdeSolver::Bdf)
+        .with_metadata(
+            super::super::metadata::new("accepted_stop_ode")
+                .states(["central"])
+                .outputs(["cp"])
+                .route(super::super::Route::infusion("iv").to_state("central")),
+        )
+        .expect("metadata should validate");
+
+        let predictions = ode
+            .simulate_subject(&subject, &crate::parameters::dense([]), None)
+            .expect("infusion simulation should succeed")
+            .0;
+
+        // Dose delivered over [5, 10], then exponential decay for 10 h:
+        // (100 * (1 - exp(-0.5 * 5)) / (0.5 * 5)) * exp(-0.5 * 10).
+        let delivered = 100.0 * (1.0 - (-2.5_f64).exp()) / 2.5;
+        let expected = delivered * (-5.0_f64).exp();
+        let pred = predictions.predictions()[1].prediction();
+        assert_relative_eq!(pred, expected, max_relative = 1e-3);
+    }
+
+    // debug/script.R hybrid phage model (subject `1` of dat.csv), with the
+    // parameters hardcoded. A large infusion rate (1e9 over 1.25e-3 h) makes
+    // the first Newton solve after every infusion boundary fail once with
+    // diffsol's convergence heuristics and then recover via step-size
+    // reduction; over a long horizon those individually recovered failures
+    // accumulate in diffsol's absolute `number_of_nonlinear_solver_fails`
+    // counter and blow up the run unless the boundary restart avoids them.
+    fn hybrid_phage_diffeq(
+        x: &V,
+        _p: &V,
+        _t: f64,
+        dx: &mut V,
+        _b: &V,
+        rateiv: &V,
+        _cov: &Covariates,
+    ) {
+        let eps = 1.0e-12_f64;
+        let soft = |v: f64| 0.5 * (v + (v * v + eps * eps).sqrt());
+
+        let kep = 20.799022436141968;
+        let k12 = 3.611151695251465;
+        let k21 = 0.20569434165954592;
+        let kdep = 3.674600839614868;
+        let kcl_air = 98.17452669143677;
+        let kgr = 2.072104573249817;
+        let kinf = 1.909232258796692e-6;
+        let c50 = 427933.12072753906;
+        let klysis = 0.8622971177101135;
+        let burst = 1.591451644897461;
+        let ksp = 4.387639760971069;
+        let kdp = 0.0917521107196808;
+        let kn = 1.147785520553589;
+        let va = 12.829959392547607;
+
+        let phage_air = soft(x[2]);
+        let bacc_pos = soft(x[3]);
+        let binf_pos = soft(x[4]);
+        let bprot_pos = soft(x[5]);
+        let tb = bacc_pos + binf_pos + bprot_pos;
+        let bmax = 10_f64.powi(10);
+        let cair = phage_air / va;
+        let inf_eff = kinf * cair / (1.0 + cair / c50);
+
+        dx[0] = -(kep + k12 + kdep) * x[0] + k21 * x[1] + rateiv[0];
+        dx[1] = k12 * x[0] - k21 * x[1];
+        dx[2] = kdep * x[0] - kcl_air * x[2] - inf_eff * bacc_pos + burst * klysis * binf_pos;
+        dx[3] = kgr * bacc_pos * (1.0 - tb / bmax) - inf_eff * bacc_pos - ksp * x[3] + kdp * x[5]
+            - kn * x[3];
+        dx[4] = inf_eff * bacc_pos - klysis * x[4];
+        dx[5] = ksp * x[3] - kdp * x[5];
+    }
+
+    fn hybrid_phage_init(_p: &V, _t: f64, _cov: &Covariates, x: &mut V) {
+        x[3] = 3.0 * 10_f64.powf(5.5);
+    }
+
+    fn run_hybrid_phage_infusions(subject: &Subject) -> Vec<f64> {
+        let ode = ODE::new(
+            hybrid_phage_diffeq,
+            zero_lag,
+            unit_fa,
+            hybrid_phage_init,
+            state_output,
+        )
+        .with_nstates(6)
+        .with_ndrugs(1)
+        .with_nout(1)
+        .with_solver(OdeSolver::Bdf)
+        .with_metadata(
+            super::super::metadata::new("hybrid_phage_infusions")
+                .states(["plasma", "peripheral", "airway", "bacc", "binf", "bprot"])
+                .outputs(["cp"])
+                .route(super::super::Route::infusion("iv").to_state("plasma")),
+        )
+        .expect("metadata should validate");
+
+        let predictions = ode
+            .simulate_subject(subject, &crate::parameters::dense([]), None)
+            .expect("hybrid phage simulation should succeed")
+            .0;
+
+        predictions
+            .predictions()
+            .iter()
+            .map(|p| p.prediction())
+            .collect()
+    }
+
+    #[test]
+    fn ode_infusions_long_horizon_boundary_failures_do_not_accumulate() {
+        // The dosing and observation schedule of debug/dat.csv subject `1`
+        // (103 short infusions): enough boundaries that, without the boundary
+        // restart handling, the individually-recovered Newton failures would
+        // accumulate past diffsol's 50-failure limit and abort the run.
+        let mut builder = Subject::builder("long_horizon_short_infusions");
+        builder = builder.infusion(0.0, 1e+09, "iv", 0.00125);
+        builder = builder.missing_observation(0.005, "cp");
+        builder = builder.missing_observation(0.01791667, "cp");
+        builder = builder.missing_observation(0.02208333, "cp");
+        builder = builder.missing_observation(0.02208333, "cp");
+        builder = builder.missing_observation(0.03458333, "cp");
+        builder = builder.missing_observation(0.03833333, "cp");
+        builder = builder.missing_observation(0.03833333, "cp");
+        builder = builder.missing_observation(0.08458333, "cp");
+        builder = builder.missing_observation(0.18625, "cp");
+        builder = builder.infusion(0.5, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(1.0, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(1.5, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(2.0, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(2.5, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(3.0, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(3.5, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(4.0, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(4.5, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(5.0, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(5.5, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(6.0, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(6.5, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(7.0, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(7.5, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(8.490833, 1e+09, "iv", 0.00125);
+        builder = builder.missing_observation(8.991667, "cp");
+        builder = builder.infusion(8.992917, 1e+09, "iv", 0.00125);
+        builder = builder.missing_observation(8.995833, "cp");
+        builder = builder.missing_observation(9.010417, "cp");
+        builder = builder.missing_observation(9.074167, "cp");
+        builder = builder.missing_observation(9.166667, "cp");
+        builder = builder.infusion(9.492917, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(9.992917, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(10.49292, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(10.99292, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(11.49292, 1e+09, "iv", 0.00125);
+        builder = builder.infusion(12.01458, 3e+09, "iv", 0.00125);
+        builder = builder.missing_observation(12.03958, "cp");
+        builder = builder.missing_observation(12.03958, "cp");
+        builder = builder.missing_observation(13.01375, "cp");
+        builder = builder.infusion(13.01542, 3e+09, "iv", 0.00125);
+        builder = builder.missing_observation(13.01792, "cp");
+        builder = builder.missing_observation(13.1925, "cp");
+        builder = builder.missing_observation(13.1925, "cp");
+        builder = builder.missing_observation(13.1925, "cp");
+        builder = builder.missing_observation(13.26875, "cp");
+        builder = builder.infusion(14.01542, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(15.01542, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(16.01542, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(17.01542, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(18.01542, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(19.01542, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(20.04917, 3e+09, "iv", 0.00125);
+        builder = builder.missing_observation(21.03333, "cp");
+        builder = builder.infusion(21.04917, 3e+09, "iv", 0.00125);
+        builder = builder.missing_observation(21.055, "cp");
+        builder = builder.missing_observation(21.06792, "cp");
+        builder = builder.infusion(22.04917, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(23.04917, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(26.05125, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(27.05125, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(28.05125, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(29.05125, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(30.05125, 3e+09, "iv", 0.00125);
+        builder = builder.missing_observation(33.05333, "cp");
+        builder = builder.infusion(33.06042, 3e+09, "iv", 0.00125);
+        builder = builder.missing_observation(33.06375, "cp");
+        builder = builder.missing_observation(34.0375, "cp");
+        builder = builder.missing_observation(34.0375, "cp");
+        builder = builder.infusion(34.06042, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(35.06042, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(36.06042, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(37.06042, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(40.06042, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(41.06042, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(42.06042, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(43.06042, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(44.06042, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(47.06042, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(48.06042, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(49.06042, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(50.06042, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(51.06042, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(54.03667, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(55.03667, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(56.17417, 3e+09, "iv", 0.00125);
+        builder = builder.missing_observation(56.21667, "cp");
+        builder = builder.missing_observation(56.21667, "cp");
+        builder = builder.infusion(57.17417, 3e+09, "iv", 0.00125);
+        builder = builder.missing_observation(58.01542, "cp");
+        builder = builder.missing_observation(58.01542, "cp");
+        builder = builder.infusion(58.17417, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(61.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(62.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(63.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(64.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(65.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(68.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(69.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(70.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(71.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(72.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(75.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(76.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(77.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(78.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(79.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(82.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(83.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(84.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(85.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(86.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(89.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(90.17583, 3e+09, "iv", 0.00125);
+        builder = builder.missing_observation(91.05958, "cp");
+        builder = builder.infusion(91.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(92.17583, 3e+09, "iv", 0.00125);
+        builder = builder.missing_observation(93.07417, "cp");
+        builder = builder.missing_observation(93.07417, "cp");
+        builder = builder.infusion(93.17583, 3e+09, "iv", 0.00125);
+        builder = builder.infusion(96.02792, 4.5e+09, "iv", 0.00125);
+        builder = builder.infusion(97.02792, 4.5e+09, "iv", 0.00125);
+        builder = builder.infusion(98.02792, 4.5e+09, "iv", 0.00125);
+        builder = builder.infusion(99.02792, 4.5e+09, "iv", 0.00125);
+        builder = builder.infusion(100.0279, 4.5e+09, "iv", 0.00125);
+        builder = builder.infusion(103.0279, 4.5e+09, "iv", 0.00125);
+        builder = builder.infusion(104.0279, 4.5e+09, "iv", 0.00125);
+        builder = builder.infusion(105.0279, 4.5e+09, "iv", 0.00125);
+        builder = builder.infusion(106.0279, 4.5e+09, "iv", 0.00125);
+        builder = builder.infusion(107.0279, 4.5e+09, "iv", 0.00125);
+        builder = builder.infusion(110.0279, 4.5e+09, "iv", 0.00125);
+        builder = builder.infusion(111.0279, 4.5e+09, "iv", 0.00125);
+        builder = builder.missing_observation(112.0271, "cp");
+        builder = builder.missing_observation(112.0271, "cp");
+        builder = builder.infusion(112.0279, 4.5e+09, "iv", 0.00125);
+        builder = builder.missing_observation(112.0742, "cp");
+        builder = builder.missing_observation(112.0742, "cp");
+        builder = builder.infusion(113.0279, 4.5e+09, "iv", 0.00125);
+        builder = builder.infusion(114.0279, 4.5e+09, "iv", 0.00125);
+        builder = builder.missing_observation(114.1333, "cp");
+        builder = builder.missing_observation(114.1333, "cp");
+        builder = builder.infusion(117.05, 4.5e+09, "iv", 0.00125);
+        builder = builder.infusion(118.05, 4.5e+09, "iv", 0.00125);
+        builder = builder.infusion(119.05, 4.5e+09, "iv", 0.00125);
+        let subject = builder.build();
+
+        let predictions = run_hybrid_phage_infusions(&subject);
+
+        // The simulation must complete and produce a finite, positive plasma
+        // prediction (the crash is the regression this guards against).
+        assert!(predictions[0].is_finite());
+        assert!(predictions[0] > 0.0);
     }
 }

--- a/src/simulator/equation/ode/mod.rs
+++ b/src/simulator/equation/ode/mod.rs
@@ -561,7 +561,11 @@ impl EquationPriv for ODE {
 ///   dynamics instead of the pre-boundary ones;
 /// - `state_mut` marks the state as modified so the next step restarts the
 ///   multi-step method at first order.
-fn reinitialize_at_boundary<'a, F, S>(solver: &mut S, dy_scratch: &mut V)
+///
+/// Shared with the DSL/JIT ODE path ([`crate::dsl::native::NativeOdeModel`]),
+/// which must apply the same discontinuity semantics as the closure-based
+/// [`ODE`] event loop.
+pub(crate) fn reinitialize_at_boundary<'a, F, S>(solver: &mut S, dy_scratch: &mut V)
 where
     F: Fn(&V, &V, f64, &mut V, &V, &V, &Covariates) + 'a,
     S: OdeSolverMethod<'a, PMProblem<'a, F>>,

--- a/src/simulator/equation/ode/mod.rs
+++ b/src/simulator/equation/ode/mod.rs
@@ -544,28 +544,6 @@ impl EquationPriv for ODE {
 }
 
 impl ODE {
-    fn infusion_end_times(events: &[Event]) -> Vec<f64> {
-        let mut stops: Vec<f64> = events
-            .iter()
-            .filter_map(|event| {
-                let infusion = match event {
-                    Event::Infusion(infusion) => infusion,
-                    _ => return None,
-                };
-                let start = infusion.time();
-                let end = start + infusion.duration();
-                if end.is_finite() && end > start {
-                    Some(end)
-                } else {
-                    None
-                }
-            })
-            .collect();
-        stops.sort_by(|a, b| a.total_cmp(b));
-        stops.dedup_by(|a, b| a == b);
-        stops
-    }
-
     /// Generic event-loop runner, parameterized over the concrete solver type.
     #[allow(clippy::too_many_arguments)]
     fn run_events<'a, F, S>(
@@ -588,8 +566,8 @@ impl ODE {
         F: Fn(&V, &V, f64, &mut V, &V, &V, &Covariates) + 'a,
         S: OdeSolverMethod<'a, PMProblem<'a, F>>,
     {
-        const STOP_TIME_EPS: f64 = 1e-12;
-        let infusion_stop_times = Self::infusion_end_times(events);
+        let infusion_end_times = solver.problem().eqn.infusion_end_times();
+        let mut infusion_end_cursor = 0usize;
         let mut index = 0usize;
         while index < events.len() {
             let event = &events[index];
@@ -671,23 +649,44 @@ impl ODE {
 
             // Advance to the next event time if it exists
             if let Some(next_event) = next_event {
-                while (next_event.time() - solver.state().t) > STOP_TIME_EPS {
-                    let mut stop_time = next_event.time();
-                    let current_t = solver.state().t;
-                    for stop in &infusion_stop_times {
-                        if stop > &(current_t + STOP_TIME_EPS)
-                            && stop < &(stop_time - STOP_TIME_EPS)
-                        {
-                            stop_time = *stop;
-                            break;
-                        }
+                let next_event_time = next_event.time();
+                while next_event_time > solver.state().t {
+                    while infusion_end_cursor < infusion_end_times.len()
+                        && infusion_end_times[infusion_end_cursor] <= solver.state().t
+                    {
+                        infusion_end_cursor += 1;
                     }
+
+                    let (stop_time, is_infusion_end) =
+                        if let Some(stop_time) = infusion_end_times.get(infusion_end_cursor) {
+                            if *stop_time <= next_event_time {
+                                infusion_end_cursor += 1;
+                                (*stop_time, true)
+                            } else {
+                                (next_event_time, false)
+                            }
+                        } else {
+                            (next_event_time, false)
+                        };
+
+                    solver
+                        .problem()
+                        .eqn
+                        .set_left_continuity_time(if is_infusion_end {
+                            Some(stop_time)
+                        } else {
+                            None
+                        });
 
                     match solver.set_stop_time(stop_time) {
                         Ok(_) => loop {
                             match solver.step() {
                                 Ok(OdeSolverStopReason::InternalTimestep) => continue,
                                 Ok(OdeSolverStopReason::TstopReached) => {
+                                    solver.problem().eqn.set_left_continuity_time(None);
+                                    if is_infusion_end {
+                                        let _ = solver.state_mut();
+                                    }
                                     break;
                                 }
                                 Ok(OdeSolverStopReason::RootFound(_, _)) => {
@@ -705,18 +704,17 @@ impl ODE {
                         Err(diffsol::error::DiffsolError::OdeSolverError(
                             OdeSolverError::StopTimeAtCurrentTime,
                         )) => {
-                            if (stop_time - solver.state().t).abs() <= STOP_TIME_EPS {
-                                {
-                                    let state = solver.state_mut();
-                                    if (stop_time - *state.t).abs() > STOP_TIME_EPS {
-                                        *state.t = stop_time;
-                                    }
-                                }
+                            solver.problem().eqn.set_left_continuity_time(None);
+                            let state_t = solver.state().t;
+                            let stop_reached = stop_time == state_t
+                                || stop_time == state_t.next_up()
+                                || stop_time == state_t.next_down();
 
-                                if (next_event.time() - stop_time).abs() <= STOP_TIME_EPS {
-                                    break;
+                            if stop_reached {
+                                if is_infusion_end && next_event_time != stop_time {
+                                    continue;
                                 }
-                                continue;
+                                break;
                             }
                             return Err(PharmsolError::from_solver_error(
                                 diffsol::error::DiffsolError::OdeSolverError(
@@ -726,6 +724,7 @@ impl ODE {
                             ));
                         }
                         Err(err) => {
+                            solver.problem().eqn.set_left_continuity_time(None);
                             return Err(PharmsolError::from_solver_error(err, stop_time));
                         }
                     }
@@ -878,6 +877,50 @@ mod tests {
 
     fn state_output(x: &V, _p: &V, _t: f64, _cov: &Covariates, y: &mut V) {
         y[0] = x[0];
+    }
+
+    fn infusion_rate_function(
+        _x: &V,
+        _p: &V,
+        _t: f64,
+        dx: &mut V,
+        _b: &V,
+        rateiv: &V,
+        _cov: &Covariates,
+    ) {
+        dx[0] = rateiv[0];
+    }
+
+    fn run_infusions(subject: &Subject, solver: OdeSolver) -> Vec<f64> {
+        let ode = ODE::new(
+            infusion_rate_function,
+            zero_lag,
+            unit_fa,
+            zero_init,
+            state_output,
+        )
+        .with_nstates(1)
+        .with_ndrugs(1)
+        .with_nout(1)
+        .with_solver(solver)
+        .with_metadata(
+            super::super::metadata::new("infusion_rate_ode")
+                .states(["central"])
+                .outputs(["cp"])
+                .route(super::super::Route::infusion("iv").to_state("central")),
+        )
+        .expect("metadata should validate");
+
+        let predictions = ode
+            .simulate_subject(subject, &crate::parameters::dense([]), None)
+            .expect("infusion simulation should succeed")
+            .0;
+
+        predictions
+            .predictions()
+            .iter()
+            .map(|p| p.prediction())
+            .collect()
     }
 
     fn counting_function(
@@ -1138,5 +1181,64 @@ mod tests {
 
         assert_eq!(first.predictions().len(), second.predictions().len());
         assert_eq!(first_calls, second_calls);
+    }
+
+    #[test]
+    fn ode_infusions_short_dose_conserved_after_infusion() {
+        let subject = Subject::builder("short_infusion")
+            .infusion(0.0, 100.0, "iv", 0.1)
+            .observation(0.5, 0.0, "cp")
+            .build();
+
+        let predictions = run_infusions(&subject, OdeSolver::Bdf);
+
+        assert_relative_eq!(predictions[0], 100.0, max_relative = 1e-4);
+    }
+
+    #[test]
+    fn ode_infusions_observation_at_infusion_end_uses_active_left_rate() {
+        let subject = Subject::builder("infusion_end_observation")
+            .infusion(0.0, 100.0, "iv", 0.1)
+            .observation(0.1, 0.0, "cp")
+            .observation(0.5, 0.0, "cp")
+            .build();
+
+        let predictions = run_infusions(&subject, OdeSolver::Bdf);
+
+        assert_relative_eq!(predictions[0], 100.0, max_relative = 1e-4);
+        assert_relative_eq!(predictions[1], 100.0, max_relative = 1e-4);
+    }
+
+    #[test]
+    fn ode_infusions_dose_conservation_with_multiple_solvers() {
+        let subject = Subject::builder("short_infusion_multi_solver")
+            .infusion(0.0, 100.0, "iv", 0.1)
+            .observation(0.5, 0.0, "cp")
+            .build();
+
+        let solvers = [
+            OdeSolver::Bdf,
+            OdeSolver::Sdirk(SdirkTableau::TrBdf2),
+            OdeSolver::Sdirk(SdirkTableau::Esdirk34),
+            OdeSolver::ExplicitRk(ExplicitRkTableau::Tsit45),
+        ];
+
+        for solver in solvers {
+            let predictions = run_infusions(&subject, solver);
+            assert_relative_eq!(predictions[0], 100.0, max_relative = 1e-2);
+        }
+    }
+
+    #[test]
+    fn ode_infusions_back_to_back_discontinuities_conserve_dose() {
+        let subject = Subject::builder("back_to_back_infusions")
+            .infusion(0.0, 100.0, "iv", 0.5)
+            .infusion(0.5, 100.0, "iv", 0.5)
+            .observation(1.0, 0.0, "cp")
+            .build();
+
+        let predictions = run_infusions(&subject, OdeSolver::Bdf);
+
+        assert_relative_eq!(predictions[0], 200.0, max_relative = 1e-4);
     }
 }

--- a/src/simulator/equation/ode/mod.rs
+++ b/src/simulator/equation/ode/mod.rs
@@ -328,6 +328,8 @@ fn _simulate_subject_dense(
     let zero_bolus = V::zeros(ndrugs, NalgebraContext::new());
     let zero_rateiv = V::zeros(ndrugs, NalgebraContext::new());
     let mut bolus_v = V::zeros(ndrugs, NalgebraContext::new());
+    // Scratch for refreshing the solver's derivative at infusion boundaries.
+    let mut dy_scratch = V::zeros(nstates, NalgebraContext::new());
     let parameters_vec = parameters.to_vec();
     let parameters_v: V = DVector::from_vec(parameters_vec.clone()).into();
 
@@ -376,6 +378,7 @@ fn _simulate_subject_dense(
                         &zero_rateiv,
                         &mut state_with_bolus,
                         &mut state_without_bolus,
+                        &mut dy_scratch,
                         &mut y_out,
                         &mut likelihood,
                         &mut output,
@@ -395,6 +398,7 @@ fn _simulate_subject_dense(
                         &zero_rateiv,
                         &mut state_with_bolus,
                         &mut state_without_bolus,
+                        &mut dy_scratch,
                         &mut y_out,
                         &mut likelihood,
                         &mut output,
@@ -414,6 +418,7 @@ fn _simulate_subject_dense(
                         &zero_rateiv,
                         &mut state_with_bolus,
                         &mut state_without_bolus,
+                        &mut dy_scratch,
                         &mut y_out,
                         &mut likelihood,
                         &mut output,
@@ -433,6 +438,7 @@ fn _simulate_subject_dense(
                         &zero_rateiv,
                         &mut state_with_bolus,
                         &mut state_without_bolus,
+                        &mut dy_scratch,
                         &mut y_out,
                         &mut likelihood,
                         &mut output,
@@ -543,6 +549,46 @@ impl EquationPriv for ODE {
     }
 }
 
+/// Restart the solver after an infusion boundary (a RHS discontinuity).
+///
+/// The multi-step history and the internal Jacobian were built for the
+/// pre-boundary RHS, so the first step into the new segment must not reuse
+/// them as-is:
+/// - `set_state` forces diffsol to recompute its BDF coefficients and
+///   reinitialize the internal Jacobian for the current state;
+/// - the stored derivative is refreshed against the post-boundary
+///   (right-continuous) RHS so a first-order restart predicts with the new
+///   dynamics instead of the pre-boundary ones;
+/// - `state_mut` marks the state as modified so the next step restarts the
+///   multi-step method at first order.
+///
+/// The first step is additionally capped just below `next_stop_time` (the
+/// stop the next segment is integrating toward): a restart step landing
+/// exactly on the next discontinuity inherits a Jacobian built for the
+/// pre-boundary order and can make the nonlinear solve oscillate, while a
+/// step that ends just before it converges cleanly (the error controller
+/// takes over from there).
+fn reinitialize_at_boundary<'a, F, S>(solver: &mut S, dy_scratch: &mut V, next_stop_time: f64)
+where
+    F: Fn(&V, &V, f64, &mut V, &V, &V, &Covariates) + 'a,
+    S: OdeSolverMethod<'a, PMProblem<'a, F>>,
+{
+    let state = solver.state_clone();
+    solver.set_state(state);
+
+    let t = solver.state().t;
+    {
+        let y = solver.state().y;
+        solver
+            .problem()
+            .eqn
+            .refresh_state_derivative(t, y, dy_scratch);
+    }
+    let state = solver.state_mut();
+    state.dy.copy_from(dy_scratch);
+    *state.h = (*state.h).min(0.9 * (next_stop_time - t).max(0.0));
+}
+
 impl ODE {
     /// Generic event-loop runner, parameterized over the concrete solver type.
     #[allow(clippy::too_many_arguments)]
@@ -558,6 +604,7 @@ impl ODE {
         zero_rateiv: &V,
         state_with_bolus: &mut V,
         state_without_bolus: &mut V,
+        dy_scratch: &mut V,
         y_out: &mut V,
         likelihood: &mut Vec<f64>,
         output: &mut SubjectPredictions,
@@ -566,9 +613,14 @@ impl ODE {
         F: Fn(&V, &V, f64, &mut V, &V, &V, &Covariates) + 'a,
         S: OdeSolverMethod<'a, PMProblem<'a, F>>,
     {
-        let infusion_end_times = solver.problem().eqn.infusion_end_times();
-        let mut infusion_end_cursor = 0usize;
+        let infusion_boundary_times = solver.problem().eqn.infusion_boundary_times();
+        let mut infusion_boundary_cursor = 0usize;
         let mut index = 0usize;
+        // Set when the previous stop was an infusion boundary: the solver must
+        // be restarted before the first step of the next segment (the RHS is
+        // discontinuous at the boundary). Deferred until the next stop time is
+        // known so the first step can be capped below it.
+        let mut pending_reinit = false;
         while index < events.len() {
             let event = &events[index];
             let next_event = events.get(index + 1);
@@ -651,28 +703,34 @@ impl ODE {
             if let Some(next_event) = next_event {
                 let next_event_time = next_event.time();
                 while next_event_time > solver.state().t {
-                    while infusion_end_cursor < infusion_end_times.len()
-                        && infusion_end_times[infusion_end_cursor] <= solver.state().t
+                    while infusion_boundary_cursor < infusion_boundary_times.len()
+                        && infusion_boundary_times[infusion_boundary_cursor] <= solver.state().t
                     {
-                        infusion_end_cursor += 1;
+                        infusion_boundary_cursor += 1;
                     }
 
-                    let (stop_time, is_infusion_end) =
-                        if let Some(stop_time) = infusion_end_times.get(infusion_end_cursor) {
-                            if *stop_time <= next_event_time {
-                                infusion_end_cursor += 1;
-                                (*stop_time, true)
-                            } else {
-                                (next_event_time, false)
-                            }
+                    let (stop_time, is_infusion_boundary) = if let Some(stop_time) =
+                        infusion_boundary_times.get(infusion_boundary_cursor)
+                    {
+                        if *stop_time <= next_event_time {
+                            infusion_boundary_cursor += 1;
+                            (*stop_time, true)
                         } else {
                             (next_event_time, false)
-                        };
+                        }
+                    } else {
+                        (next_event_time, false)
+                    };
+
+                    if pending_reinit {
+                        reinitialize_at_boundary(solver, dy_scratch, stop_time);
+                        pending_reinit = false;
+                    }
 
                     solver
                         .problem()
                         .eqn
-                        .set_left_continuity_time(if is_infusion_end {
+                        .set_left_continuity_time(if is_infusion_boundary {
                             Some(stop_time)
                         } else {
                             None
@@ -684,8 +742,8 @@ impl ODE {
                                 Ok(OdeSolverStopReason::InternalTimestep) => continue,
                                 Ok(OdeSolverStopReason::TstopReached) => {
                                     solver.problem().eqn.set_left_continuity_time(None);
-                                    if is_infusion_end {
-                                        let _ = solver.state_mut();
+                                    if is_infusion_boundary {
+                                        pending_reinit = true;
                                     }
                                     break;
                                 }
@@ -711,8 +769,8 @@ impl ODE {
                                 || stop_time == state_t.next_down();
 
                             if stop_reached {
-                                if is_infusion_end && next_event_time != stop_time {
-                                    continue;
+                                if is_infusion_boundary {
+                                    pending_reinit = true;
                                 }
                                 break;
                             }
@@ -1211,22 +1269,37 @@ mod tests {
 
     #[test]
     fn ode_infusions_dose_conservation_with_multiple_solvers() {
+        // Genuinely short infusion (0.01 h), representative of the reported
+        // failures; the dose must be fully conserved across all solver types.
         let subject = Subject::builder("short_infusion_multi_solver")
-            .infusion(0.0, 100.0, "iv", 0.1)
-            .observation(0.5, 0.0, "cp")
+            .infusion(0.0, 100.0, "iv", 0.01)
+            .observation(0.01, 0.0, "cp")
             .build();
 
         let solvers = [
-            OdeSolver::Bdf,
-            OdeSolver::Sdirk(SdirkTableau::TrBdf2),
-            OdeSolver::Sdirk(SdirkTableau::Esdirk34),
-            OdeSolver::ExplicitRk(ExplicitRkTableau::Tsit45),
+            (OdeSolver::Bdf, "Bdf"),
+            (OdeSolver::Sdirk(SdirkTableau::TrBdf2), "TrBdf2"),
+            (OdeSolver::Sdirk(SdirkTableau::Esdirk34), "Esdirk34"),
+            (OdeSolver::ExplicitRk(ExplicitRkTableau::Tsit45), "Tsit45"),
         ];
 
-        for solver in solvers {
+        for (solver, _label) in solvers {
             let predictions = run_infusions(&subject, solver);
-            assert_relative_eq!(predictions[0], 100.0, max_relative = 1e-2);
+            assert_relative_eq!(predictions[0], 100.0, max_relative = 1e-4);
         }
+    }
+
+    #[test]
+    fn ode_infusions_delayed_short_dose_with_bdf() {
+        let subject = Subject::builder("short_infusion_delayed_start_bdf")
+            .observation(0.0, 0.0, "cp")
+            .infusion(0.5, 100.0, "iv", 0.01)
+            .observation(0.52, 0.0, "cp")
+            .build();
+
+        let predictions = run_infusions(&subject, OdeSolver::Bdf);
+
+        assert_relative_eq!(predictions[1], 100.0, max_relative = 1e-4);
     }
 
     #[test]


### PR DESCRIPTION
This should solve many of the issues with the solver crashing because of the stiffness (discontinuities) introduced by some very short and sharp infusions