### PR TITLE
Feat/if braces

### DIFF
--- a/pharmsol-dsl/src/authoring.rs
+++ b/pharmsol-dsl/src/authoring.rs
@@ -103,14 +103,54 @@ impl<'a> AuthoringParser<'a> {
 
     fn parse_module(mut self) -> Result<Module, ParseError> {
         let mut offset = 0;
-        for segment in self.src.split_inclusive('\n') {
+        let mut pending: Option<String> = None;
+        let mut pending_start = 0;
+        let mut brace_depth = 0i32;
+        let mut segments = self.src.split_inclusive('\n').peekable();
+        while let Some(segment) = segments.next() {
             let line = segment.strip_suffix('\n').unwrap_or(segment);
-            self.parse_line(line, offset)?;
+            let code = &line[..line.find('#').unwrap_or(line.len())];
+            let (opens, closes) = brace_counts(code);
+            let starts_with_else = starts_with_keyword(code.trim_start(), "else");
+            if pending.is_none()
+                && brace_depth == 0
+                && opens == 0
+                && closes == 0
+                && !starts_with_else
+            {
+                self.parse_line(line, offset)?;
+                offset += segment.len();
+                continue;
+            }
+
+            if pending.is_none() {
+                pending = Some(String::new());
+                pending_start = offset;
+            }
+            if let Some(text) = &mut pending {
+                text.push_str(code);
+                text.push('\n');
+            }
+            brace_depth += opens - closes;
+
+            if brace_depth <= 0 {
+                let next_is_else = segments.peek().is_some_and(|next| {
+                    let next_line = next.strip_suffix('\n').unwrap_or(next);
+                    let next_code = &next_line[..next_line.find('#').unwrap_or(next_line.len())];
+                    starts_with_keyword(next_code.trim_start(), "else")
+                });
+                if !next_is_else {
+                    let text = pending.take().unwrap();
+                    self.parse_line(text.trim_end_matches('\n'), pending_start)?;
+                    pending_start = 0;
+                    brace_depth = 0;
+                }
+            }
             offset += segment.len();
         }
 
-        if !self.src.is_empty() && !self.src.ends_with('\n') && offset < self.src.len() {
-            self.parse_line(&self.src[offset..], offset)?;
+        if let Some(text) = pending {
+            self.parse_line(text.trim_end_matches('\n'), pending_start)?;
         }
 
         self.validate_declared_outputs_assigned()?;
@@ -320,6 +360,12 @@ impl<'a> AuthoringParser<'a> {
         let span = Span::new(line_offset + leading, line_offset + trailing);
         self.note_span(span);
 
+        if starts_with_keyword(trimmed, "if") {
+            let stmt = self.parse_if_statement(trimmed, span.start, span)?;
+            self.derive_statements.push(stmt);
+            return Ok(());
+        }
+
         if let Some(arrow) = find_top_level_arrow(trimmed) {
             return self.parse_route_line(trimmed, arrow, span.start, span);
         }
@@ -489,6 +535,162 @@ impl<'a> AuthoringParser<'a> {
             self.derive_statements.push(stmt);
         }
         Ok(())
+    }
+
+    fn parse_if_statement(
+        &mut self,
+        text: &str,
+        abs_start: usize,
+        span: Span,
+    ) -> Result<Stmt, ParseError> {
+        let rest = &text[2..];
+        let rest_leading = rest.len() - rest.trim_start().len();
+        let rest = &rest[rest_leading..];
+        let rest_abs = abs_start + 2 + rest_leading;
+        if !rest.starts_with('(') {
+            return Err(ParseError::new(
+                "expected `(` after `if`",
+                Span::new(rest_abs, rest_abs + rest.len().min(1)),
+            ));
+        }
+        let close = find_matching_delimiter(rest, '(', ')').ok_or_else(|| {
+            ParseError::new(
+                "unclosed `(` in `if` condition",
+                Span::new(rest_abs, rest_abs + rest.len()),
+            )
+        })?;
+        let condition = parse_expr_at(&rest[1..close], rest_abs + 1)?;
+        let remaining = &rest[close + 1..];
+        let remaining_abs = rest_abs + close + 1;
+
+        let (then_branch, then_consumed) = self.parse_if_body(remaining, remaining_abs)?;
+
+        let after_then = &remaining[then_consumed..];
+        let after_then_leading = after_then.len() - after_then.trim_start().len();
+        let after_then_trimmed = &after_then[after_then_leading..];
+        let after_then_abs = remaining_abs + then_consumed + after_then_leading;
+
+        let else_branch = if after_then_trimmed.is_empty() {
+            None
+        } else {
+            if !starts_with_keyword(after_then_trimmed, "else") {
+                return Err(ParseError::new(
+                    "expected `else` or end of `if`",
+                    Span::new(
+                        after_then_abs,
+                        after_then_abs + after_then_trimmed.len().min(1),
+                    ),
+                ));
+            }
+            let else_rest = &after_then_trimmed[4..];
+            let else_rest_leading = else_rest.len() - else_rest.trim_start().len();
+            let else_rest_trimmed = &else_rest[else_rest_leading..];
+            let else_rest_abs = after_then_abs + 4 + else_rest_leading;
+            if starts_with_keyword(else_rest_trimmed, "if") {
+                let nested_span = Span::new(else_rest_abs, else_rest_abs + else_rest_trimmed.len());
+                let nested =
+                    self.parse_if_statement(else_rest_trimmed, else_rest_abs, nested_span)?;
+                Some(vec![nested])
+            } else {
+                let (stmts, _consumed) = self.parse_if_body(else_rest_trimmed, else_rest_abs)?;
+                Some(stmts)
+            }
+        };
+
+        Ok(Stmt {
+            span,
+            kind: StmtKind::If(IfStmt {
+                condition,
+                then_branch,
+                else_branch,
+            }),
+        })
+    }
+
+    fn parse_if_body(
+        &mut self,
+        text: &str,
+        abs_start: usize,
+    ) -> Result<(Vec<Stmt>, usize), ParseError> {
+        let trimmed = text.trim_start();
+        let leading = text.len() - trimmed.len();
+        let abs = abs_start + leading;
+        if !trimmed.starts_with('{') {
+            return Err(ParseError::new(
+                "expected `{` to open `if`/`else` body",
+                Span::new(abs, abs + trimmed.len().min(1)),
+            ));
+        }
+        let close = find_matching_delimiter(trimmed, '{', '}').ok_or_else(|| {
+            ParseError::new(
+                "unclosed `{` in `if`/`else` body",
+                Span::new(abs, abs + trimmed.len()),
+            )
+        })?;
+        let inner = &trimmed[1..close];
+        let inner_abs = abs + 1;
+        let mut statements = Vec::new();
+        for (start, end) in split_statement_chunks(inner) {
+            let chunk = &inner[start..end];
+            let stmt = self.parse_authoring_statement(chunk, inner_abs + start)?;
+            statements.push(stmt);
+        }
+        Ok((statements, leading + close + 1))
+    }
+
+    fn parse_authoring_statement(
+        &mut self,
+        text: &str,
+        abs_start: usize,
+    ) -> Result<Stmt, ParseError> {
+        let trimmed = text.trim();
+        let leading = text.len() - text.trim_start().len();
+        let abs = abs_start + leading;
+        if trimmed.is_empty() {
+            return Err(ParseError::new(
+                "empty statement in `if` body",
+                Span::new(abs, abs),
+            ));
+        }
+        if starts_with_keyword(trimmed, "if") {
+            let span = Span::new(abs, abs + trimmed.len());
+            return self.parse_if_statement(trimmed, abs, span);
+        }
+        let eq = find_top_level_assignment(trimmed).ok_or_else(|| {
+            ParseError::new(
+                "expected an assignment (`name = <expression>`) or `if` in `if` body",
+                Span::new(abs, abs + trimmed.len().min(1)),
+            )
+        })?;
+        let lhs = &trimmed[..eq];
+        let rhs = &trimmed[eq + 1..];
+        let lhs_trimmed = lhs.trim();
+        let lhs_leading = lhs.len() - lhs.trim_start().len();
+        let lhs_abs = abs + lhs_leading;
+        let rhs_trimmed = rhs.trim();
+        let rhs_leading = rhs.len() - rhs.trim_start().len();
+        let rhs_abs = abs + eq + 1 + rhs_leading;
+        if lhs_trimmed.is_empty() || rhs_trimmed.is_empty() {
+            return Err(ParseError::new(
+                "expected `name = <expression>`",
+                Span::new(abs, abs + trimmed.len().min(1)),
+            ));
+        }
+        if lhs_trimmed.contains('(') {
+            return Err(ParseError::new(
+                "unsupported call-style assignment in `if` body",
+                Span::new(lhs_abs, lhs_abs + lhs_trimmed.len()),
+            ));
+        }
+        let target = parse_ident_segment(lhs_trimmed, lhs_abs)?;
+        let rhs = parse_surface_rhs(rhs_trimmed, rhs_abs)?;
+        Ok(build_assignment_statement(
+            AssignTarget {
+                span: Span::new(lhs_abs, lhs_abs + lhs_trimmed.len()),
+                kind: AssignTargetKind::Name(target),
+            },
+            rhs,
+        ))
     }
 
     fn parse_route_line(
@@ -1198,6 +1400,34 @@ fn parse_surface_rhs_at(
     Ok(SurfaceRhs::Expr(parse_expr_at(src, abs_start)?))
 }
 
+fn parse_surface_rhs_body(
+    src: &str,
+    abs_start: usize,
+    depth: usize,
+) -> Result<(SurfaceRhs, usize), ParseError> {
+    let trimmed = src.trim_start();
+    let leading = src.len() - trimmed.len();
+    let abs = abs_start + leading;
+    if trimmed.starts_with('{') {
+        let close = find_matching_delimiter(trimmed, '{', '}').ok_or_else(|| {
+            ParseError::new(
+                "unclosed `{` in conditional expression",
+                Span::new(abs, abs + trimmed.len()),
+            )
+        })?;
+        let inner = &trimmed[1..close];
+        let inner_leading = inner.len() - inner.trim_start().len();
+        let inner_trimmed = &inner[inner_leading..];
+        let inner_trailing = inner_trimmed.trim_end().len();
+        let inner_trimmed = &inner_trimmed[..inner_trailing];
+        let inner_abs = abs + 1 + inner_leading;
+        let rhs = parse_surface_rhs_at(inner_trimmed, inner_abs, depth + 1)?;
+        return Ok((rhs, leading + close + 1));
+    }
+    let rhs = parse_surface_rhs_at(trimmed, abs, depth + 1)?;
+    Ok((rhs, leading + trimmed.len()))
+}
+
 fn parse_if_rhs(src: &str, abs_start: usize, depth: usize) -> Result<SurfaceRhs, ParseError> {
     if depth >= crate::parser::MAX_NESTING_DEPTH {
         return Err(ParseError::new(
@@ -1237,12 +1467,20 @@ fn parse_if_rhs(src: &str, abs_start: usize, depth: usize) -> Result<SurfaceRhs,
     })?;
 
     let condition = parse_expr_at(condition_src, rest_abs + 1)?;
-    let then_branch = parse_surface_rhs_at(&remaining[..else_index], remaining_abs, depth + 1)?;
-    let else_branch = parse_surface_rhs_at(
-        &remaining[else_index + 4..],
-        remaining_abs + else_index + 4,
-        depth + 1,
-    )?;
+    let (then_branch, _) = parse_surface_rhs_body(&remaining[..else_index], remaining_abs, depth)?;
+    let else_src = &remaining[else_index + 4..];
+    let else_abs = remaining_abs + else_index + 4;
+    let (else_branch, else_consumed) = parse_surface_rhs_body(else_src, else_abs, depth)?;
+    let trailing_src = &else_src[else_consumed..];
+    let trailing = trailing_src.trim_start();
+    let trailing_leading = trailing_src.len() - trailing.len();
+    let trailing_pos = else_abs + else_consumed + trailing_leading;
+    if !trailing.is_empty() {
+        return Err(ParseError::new(
+            "unexpected tokens after `if`/`else` expression",
+            Span::new(trailing_pos, trailing_pos + trailing.len()),
+        ));
+    }
     let span = Span::new(abs_start, remaining_abs + remaining.len());
 
     Ok(SurfaceRhs::If {
@@ -1506,21 +1744,35 @@ fn find_top_level_operator(src: &str, operator: &str) -> Option<usize> {
 }
 
 fn find_top_level_keyword(src: &str, keyword: &str) -> Option<usize> {
-    let mut paren_depth = 0;
-    let mut bracket_depth = 0;
+    let mut paren_depth = 0i32;
+    let mut bracket_depth = 0i32;
+    let mut brace_depth = 0i32;
+    let mut in_string = false;
     let bytes = src.as_bytes();
     let keyword_bytes = keyword.as_bytes();
     let mut index = 0;
     while index + keyword_bytes.len() <= bytes.len() {
-        match bytes[index] as char {
-            '(' => paren_depth += 1,
-            ')' => paren_depth -= 1,
-            '[' => bracket_depth += 1,
-            ']' => bracket_depth -= 1,
+        let byte = bytes[index];
+        if in_string {
+            if byte == b'"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+        match byte {
+            b'"' => in_string = true,
+            b'(' => paren_depth += 1,
+            b')' => paren_depth -= 1,
+            b'[' => bracket_depth += 1,
+            b']' => bracket_depth -= 1,
+            b'{' => brace_depth += 1,
+            b'}' => brace_depth -= 1,
             _ => {}
         }
         if paren_depth == 0
             && bracket_depth == 0
+            && brace_depth == 0
             && &bytes[index..index + keyword_bytes.len()] == keyword_bytes
         {
             let prev = index.checked_sub(1).and_then(|idx| bytes.get(idx)).copied();
@@ -1536,10 +1788,81 @@ fn find_top_level_keyword(src: &str, keyword: &str) -> Option<usize> {
     None
 }
 
+fn brace_counts(src: &str) -> (i32, i32) {
+    let mut opens = 0i32;
+    let mut closes = 0i32;
+    let mut in_string = false;
+    let chars = src.chars().peekable();
+    for ch in chars {
+        if in_string {
+            if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            '{' => opens += 1,
+            '}' => closes += 1,
+            _ => {}
+        }
+    }
+    (opens, closes)
+}
+
+fn split_statement_chunks(src: &str) -> Vec<(usize, usize)> {
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    let mut paren_depth = 0;
+    let mut bracket_depth = 0;
+    let mut brace_depth = 0;
+    let mut index = 0;
+    while index < src.len() {
+        match src.as_bytes()[index] {
+            b'(' => paren_depth += 1,
+            b')' => paren_depth -= 1,
+            b'[' => bracket_depth += 1,
+            b']' => bracket_depth -= 1,
+            b'{' => brace_depth += 1,
+            b'}' => brace_depth -= 1,
+            b';' | b'\n' if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 => {
+                chunks.push((start, index));
+                start = index + 1;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    chunks.push((start, src.len()));
+
+    let mut result = Vec::new();
+    for (a, b) in chunks {
+        let text = &src[a..b];
+        let trimmed_start = text.trim_start();
+        let leading = text.len() - trimmed_start.len();
+        let trimmed_end = trimmed_start.trim_end();
+        let trailing = trimmed_start.len() - trimmed_end.len();
+        if trimmed_end.is_empty() {
+            continue;
+        }
+        result.push((a + leading, b - trailing));
+    }
+    result
+}
+
 fn find_matching_delimiter(src: &str, open: char, close: char) -> Option<usize> {
-    let mut depth = 0;
+    let mut depth = 0i32;
+    let mut in_string = false;
     for (index, ch) in src.char_indices() {
-        if ch == open {
+        if in_string {
+            if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if ch == '"' {
+            in_string = true;
+        } else if ch == open {
             depth += 1;
         } else if ch == close {
             depth -= 1;

--- a/pharmsol-dsl/src/authoring.rs
+++ b/pharmsol-dsl/src/authoring.rs
@@ -106,8 +106,11 @@ impl<'a> AuthoringParser<'a> {
         let mut pending: Option<String> = None;
         let mut pending_start = 0;
         let mut brace_depth = 0i32;
-        let mut segments = self.src.split_inclusive('\n').peekable();
-        while let Some(segment) = segments.next() {
+        let segments: Vec<&str> = self.src.split_inclusive('\n').collect();
+        let mut index = 0;
+        while index < segments.len() {
+            let segment = segments[index];
+            index += 1;
             let line = segment.strip_suffix('\n').unwrap_or(segment);
             let code = &line[..line.find('#').unwrap_or(line.len())];
             let (opens, closes) = brace_counts(code);
@@ -128,17 +131,24 @@ impl<'a> AuthoringParser<'a> {
                 pending_start = offset;
             }
             if let Some(text) = &mut pending {
-                text.push_str(code);
+                text.push_str(&mask_comments(line));
                 text.push('\n');
             }
             brace_depth += opens - closes;
 
             if brace_depth <= 0 {
-                let next_is_else = segments.peek().is_some_and(|next| {
-                    let next_line = next.strip_suffix('\n').unwrap_or(next);
-                    let next_code = &next_line[..next_line.find('#').unwrap_or(next_line.len())];
-                    starts_with_keyword(next_code.trim_start(), "else")
-                });
+                let next_is_else = segments[index..]
+                    .iter()
+                    .find(|next| {
+                        let next_line = next.strip_suffix('\n').unwrap_or(next);
+                        let next_code = &next_line[..next_line.find('#').unwrap_or(next_line.len())];
+                        !next_code.trim().is_empty()
+                    })
+                    .is_some_and(|next| {
+                        let next_line = next.strip_suffix('\n').unwrap_or(next);
+                        let next_code = &next_line[..next_line.find('#').unwrap_or(next_line.len())];
+                        starts_with_keyword(next_code.trim_start(), "else")
+                    });
                 if !next_is_else {
                     let text = pending.take().unwrap();
                     self.parse_line(text.trim_end_matches('\n'), pending_start)?;
@@ -586,15 +596,26 @@ impl<'a> AuthoringParser<'a> {
             let else_rest_leading = else_rest.len() - else_rest.trim_start().len();
             let else_rest_trimmed = &else_rest[else_rest_leading..];
             let else_rest_abs = after_then_abs + 4 + else_rest_leading;
-            if starts_with_keyword(else_rest_trimmed, "if") {
+            let (stmts, else_consumed) = if starts_with_keyword(else_rest_trimmed, "if") {
                 let nested_span = Span::new(else_rest_abs, else_rest_abs + else_rest_trimmed.len());
                 let nested =
                     self.parse_if_statement(else_rest_trimmed, else_rest_abs, nested_span)?;
-                Some(vec![nested])
+                (vec![nested], else_rest_trimmed.len())
             } else {
-                let (stmts, _consumed) = self.parse_if_body(else_rest_trimmed, else_rest_abs)?;
-                Some(stmts)
+                let (stmts, consumed) = self.parse_if_body(else_rest_trimmed, else_rest_abs)?;
+                (stmts, consumed)
+            };
+            let trailing_src = &else_rest_trimmed[else_consumed..];
+            let trailing = trailing_src.trim_start();
+            let trailing_leading = trailing_src.len() - trailing.len();
+            let trailing_abs = else_rest_abs + else_consumed + trailing_leading;
+            if !trailing.is_empty() {
+                return Err(ParseError::new(
+                    "unexpected tokens after `if`/`else` statement",
+                    Span::new(trailing_abs, trailing_abs + trailing.len()),
+                ));
             }
+            Some(stmts)
         };
 
         Ok(Stmt {
@@ -678,7 +699,10 @@ impl<'a> AuthoringParser<'a> {
         }
         if lhs_trimmed.contains('(') {
             return Err(ParseError::new(
-                "unsupported call-style assignment in `if` body",
+                "an `if` statement body supports only plain-variable assignments \
+                 (`x = <expression>`); to make `ddt(...)`, `out(...)`, or `init(...)` \
+                 conditional, use a conditional equation instead, e.g. \
+                 `ddt(central) = if (cond) <a> else <b>`",
                 Span::new(lhs_abs, lhs_abs + lhs_trimmed.len()),
             ));
         }
@@ -1788,6 +1812,16 @@ fn find_top_level_keyword(src: &str, keyword: &str) -> Option<usize> {
     None
 }
 
+fn mask_comments(line: &str) -> String {
+    let cutoff = line.find('#').unwrap_or(line.len());
+    let mut out = String::with_capacity(line.len());
+    out.push_str(&line[..cutoff]);
+    for _ in cutoff..line.len() {
+        out.push(' ');
+    }
+    out
+}
+
 fn brace_counts(src: &str) -> (i32, i32) {
     let mut opens = 0i32;
     let mut closes = 0i32;
@@ -1826,8 +1860,17 @@ fn split_statement_chunks(src: &str) -> Vec<(usize, usize)> {
             b'{' => brace_depth += 1,
             b'}' => brace_depth -= 1,
             b';' | b'\n' if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 => {
-                chunks.push((start, index));
-                start = index + 1;
+                // `else` continues the preceding `if` statement, so a boundary
+                // before one (across whitespace and blank/comment-masked lines)
+                // must not split the chunk. Same logical rule as at module level.
+                let mut next = index + 1;
+                while next < src.len() && src.as_bytes()[next].is_ascii_whitespace() {
+                    next += 1;
+                }
+                if !starts_with_keyword(&src[next..], "else") {
+                    chunks.push((start, index));
+                    start = index + 1;
+                }
             }
             _ => {}
         }

--- a/pharmsol-dsl/src/authoring.rs
+++ b/pharmsol-dsl/src/authoring.rs
@@ -141,12 +141,14 @@ impl<'a> AuthoringParser<'a> {
                     .iter()
                     .find(|next| {
                         let next_line = next.strip_suffix('\n').unwrap_or(next);
-                        let next_code = &next_line[..next_line.find('#').unwrap_or(next_line.len())];
+                        let next_code =
+                            &next_line[..next_line.find('#').unwrap_or(next_line.len())];
                         !next_code.trim().is_empty()
                     })
                     .is_some_and(|next| {
                         let next_line = next.strip_suffix('\n').unwrap_or(next);
-                        let next_code = &next_line[..next_line.find('#').unwrap_or(next_line.len())];
+                        let next_code =
+                            &next_line[..next_line.find('#').unwrap_or(next_line.len())];
                         starts_with_keyword(next_code.trim_start(), "else")
                     });
                 if !next_is_else {
@@ -614,11 +616,16 @@ impl<'a> AuthoringParser<'a> {
             let else_rest_abs = after_then_abs + 4 + else_rest_leading;
             let (stmts, else_consumed) = if starts_with_keyword(else_rest_trimmed, "if") {
                 let nested_span = Span::new(else_rest_abs, else_rest_abs + else_rest_trimmed.len());
-                let nested =
-                    self.parse_if_statement(else_rest_trimmed, else_rest_abs, nested_span, depth + 1)?;
+                let nested = self.parse_if_statement(
+                    else_rest_trimmed,
+                    else_rest_abs,
+                    nested_span,
+                    depth + 1,
+                )?;
                 (vec![nested], else_rest_trimmed.len())
             } else {
-                let (stmts, consumed) = self.parse_if_body(else_rest_trimmed, else_rest_abs, depth)?;
+                let (stmts, consumed) =
+                    self.parse_if_body(else_rest_trimmed, else_rest_abs, depth)?;
                 (stmts, consumed)
             };
             let trailing_src = &else_rest_trimmed[else_consumed..];

--- a/pharmsol-dsl/src/authoring.rs
+++ b/pharmsol-dsl/src/authoring.rs
@@ -371,7 +371,7 @@ impl<'a> AuthoringParser<'a> {
         self.note_span(span);
 
         if starts_with_keyword(trimmed, "if") {
-            let stmt = self.parse_if_statement(trimmed, span.start, span)?;
+            let stmt = self.parse_if_statement(trimmed, span.start, span, 0)?;
             self.derive_statements.push(stmt);
             return Ok(());
         }
@@ -552,7 +552,23 @@ impl<'a> AuthoringParser<'a> {
         text: &str,
         abs_start: usize,
         span: Span,
+        depth: usize,
     ) -> Result<Stmt, ParseError> {
+        // Statement-level `if` nesting is capped at half of [`MAX_NESTING_DEPTH`]
+        // (which remains the limit for expressions): each statement level spans
+        // three parser frames (`parse_if_statement` -> `parse_if_body` ->
+        // `parse_authoring_statement`), and at the full limit the unoptimized
+        // stack usage (~9.5 KB/level) would exhaust a default 2 MiB thread
+        // stack before the guard could fire.
+        if depth >= crate::parser::MAX_NESTING_DEPTH / 2 {
+            return Err(ParseError::new(
+                format!(
+                    "statement `if` is nested too deeply (maximum nesting depth is {})",
+                    crate::parser::MAX_NESTING_DEPTH / 2
+                ),
+                Span::new(abs_start, abs_start + text.len().min(2)),
+            ));
+        }
         let rest = &text[2..];
         let rest_leading = rest.len() - rest.trim_start().len();
         let rest = &rest[rest_leading..];
@@ -573,7 +589,7 @@ impl<'a> AuthoringParser<'a> {
         let remaining = &rest[close + 1..];
         let remaining_abs = rest_abs + close + 1;
 
-        let (then_branch, then_consumed) = self.parse_if_body(remaining, remaining_abs)?;
+        let (then_branch, then_consumed) = self.parse_if_body(remaining, remaining_abs, depth)?;
 
         let after_then = &remaining[then_consumed..];
         let after_then_leading = after_then.len() - after_then.trim_start().len();
@@ -599,10 +615,10 @@ impl<'a> AuthoringParser<'a> {
             let (stmts, else_consumed) = if starts_with_keyword(else_rest_trimmed, "if") {
                 let nested_span = Span::new(else_rest_abs, else_rest_abs + else_rest_trimmed.len());
                 let nested =
-                    self.parse_if_statement(else_rest_trimmed, else_rest_abs, nested_span)?;
+                    self.parse_if_statement(else_rest_trimmed, else_rest_abs, nested_span, depth + 1)?;
                 (vec![nested], else_rest_trimmed.len())
             } else {
-                let (stmts, consumed) = self.parse_if_body(else_rest_trimmed, else_rest_abs)?;
+                let (stmts, consumed) = self.parse_if_body(else_rest_trimmed, else_rest_abs, depth)?;
                 (stmts, consumed)
             };
             let trailing_src = &else_rest_trimmed[else_consumed..];
@@ -632,6 +648,7 @@ impl<'a> AuthoringParser<'a> {
         &mut self,
         text: &str,
         abs_start: usize,
+        depth: usize,
     ) -> Result<(Vec<Stmt>, usize), ParseError> {
         let trimmed = text.trim_start();
         let leading = text.len() - trimmed.len();
@@ -653,7 +670,7 @@ impl<'a> AuthoringParser<'a> {
         let mut statements = Vec::new();
         for (start, end) in split_statement_chunks(inner) {
             let chunk = &inner[start..end];
-            let stmt = self.parse_authoring_statement(chunk, inner_abs + start)?;
+            let stmt = self.parse_authoring_statement(chunk, inner_abs + start, depth)?;
             statements.push(stmt);
         }
         Ok((statements, leading + close + 1))
@@ -663,6 +680,7 @@ impl<'a> AuthoringParser<'a> {
         &mut self,
         text: &str,
         abs_start: usize,
+        depth: usize,
     ) -> Result<Stmt, ParseError> {
         let trimmed = text.trim();
         let leading = text.len() - text.trim_start().len();
@@ -675,7 +693,7 @@ impl<'a> AuthoringParser<'a> {
         }
         if starts_with_keyword(trimmed, "if") {
             let span = Span::new(abs, abs + trimmed.len());
-            return self.parse_if_statement(trimmed, abs, span);
+            return self.parse_if_statement(trimmed, abs, span, depth + 1);
         }
         let eq = find_top_level_assignment(trimmed).ok_or_else(|| {
             ParseError::new(
@@ -1491,7 +1509,18 @@ fn parse_if_rhs(src: &str, abs_start: usize, depth: usize) -> Result<SurfaceRhs,
     })?;
 
     let condition = parse_expr_at(condition_src, rest_abs + 1)?;
-    let (then_branch, _) = parse_surface_rhs_body(&remaining[..else_index], remaining_abs, depth)?;
+    let then_src = &remaining[..else_index];
+    let (then_branch, then_consumed) = parse_surface_rhs_body(then_src, remaining_abs, depth)?;
+    let then_trailing_src = &then_src[then_consumed..];
+    let then_trailing = then_trailing_src.trim_start();
+    let then_trailing_leading = then_trailing_src.len() - then_trailing.len();
+    let then_trailing_pos = remaining_abs + then_consumed + then_trailing_leading;
+    if !then_trailing.is_empty() {
+        return Err(ParseError::new(
+            "unexpected tokens after `if`/`else` expression",
+            Span::new(then_trailing_pos, then_trailing_pos + then_trailing.len()),
+        ));
+    }
     let else_src = &remaining[else_index + 4..];
     let else_abs = remaining_abs + else_index + 4;
     let (else_branch, else_consumed) = parse_surface_rhs_body(else_src, else_abs, depth)?;

--- a/pharmsol-dsl/tests/dsl_authoring_edge_cases.rs
+++ b/pharmsol-dsl/tests/dsl_authoring_edge_cases.rs
@@ -836,8 +836,7 @@ if (ke > 0.5) {
 "#;
     let model = parse_model(src).expect("braced if authoring model parses");
     let analyzed = analyze_model(&model).expect("braced if model analyzes");
-    let compiled =
-        compile_analyzed_model(&analyzed).expect("braced if model compiles");
+    let compiled = compile_analyzed_model(&analyzed).expect("braced if model compiles");
 
     let mut shapes = Vec::new();
     let function = compiled
@@ -846,7 +845,11 @@ if (ke > 0.5) {
     if let pharmsol_dsl::execution::FunctionBody::Statements(program) = &function.body {
         collect_if_branch_lens(&program.body.statements, &mut shapes);
     }
-    assert_eq!(shapes, vec![(1, Some(1))], "one if with one stmt per branch");
+    assert_eq!(
+        shapes,
+        vec![(1, Some(1))],
+        "one if with one stmt per branch"
+    );
 }
 
 #[test]
@@ -867,8 +870,7 @@ if (ke > 1) {
 "#;
     let model = parse_model(src).expect("else-if chain parses");
     let analyzed = analyze_model(&model).expect("else-if chain analyzes");
-    let compiled =
-        compile_analyzed_model(&analyzed).expect("else-if chain compiles");
+    let compiled = compile_analyzed_model(&analyzed).expect("else-if chain compiles");
 
     let mut shapes = Vec::new();
     let function = compiled
@@ -897,8 +899,7 @@ out(cp) = if (ke > 0.5) { central / v } else { central / (2 * v) }
 "#;
     let model = parse_model(src).expect("braced if-expression parses");
     let analyzed = analyze_model(&model).expect("braced if-expression analyzes");
-    let compiled =
-        compile_analyzed_model(&analyzed).expect("braced if-expression compiles");
+    let compiled = compile_analyzed_model(&analyzed).expect("braced if-expression compiles");
 
     let mut shapes = Vec::new();
     let function = compiled
@@ -962,8 +963,7 @@ if (ke > 0.5) { x = 1 } else { x = 2 }
 "#;
     let model = parse_model(src).expect("single-line statement if parses");
     let analyzed = analyze_model(&model).expect("single-line statement if analyzes");
-    let compiled =
-        compile_analyzed_model(&analyzed).expect("single-line statement if compiles");
+    let compiled = compile_analyzed_model(&analyzed).expect("single-line statement if compiles");
 
     let mut shapes = Vec::new();
     let function = compiled
@@ -991,8 +991,7 @@ out(cp) = if (ke > 0.5) {
 "#;
     let model = parse_model(src).expect("multi-line if-expression parses");
     let analyzed = analyze_model(&model).expect("multi-line if-expression analyzes");
-    let compiled =
-        compile_analyzed_model(&analyzed).expect("multi-line if-expression compiles");
+    let compiled = compile_analyzed_model(&analyzed).expect("multi-line if-expression compiles");
 
     let mut shapes = Vec::new();
     let function = compiled
@@ -1021,8 +1020,7 @@ if (ke > 0.5) {
 "#;
     let model = parse_model(src).expect("commented if block parses");
     let analyzed = analyze_model(&model).expect("commented if block analyzes");
-    let compiled =
-        compile_analyzed_model(&analyzed).expect("commented if block compiles");
+    let compiled = compile_analyzed_model(&analyzed).expect("commented if block compiles");
 
     let mut shapes = Vec::new();
     let function = compiled
@@ -1046,8 +1044,7 @@ out(cp) = if (ka > 1) { if (kb > 0.5) { 1 } else { 2 } } else { 3 }
 "#;
     let model = parse_model(src).expect("nested braced if-expression parses");
     let analyzed = analyze_model(&model).expect("nested braced if-expression analyzes");
-    let compiled = compile_analyzed_model(&analyzed)
-        .expect("nested braced if-expression compiles");
+    let compiled = compile_analyzed_model(&analyzed).expect("nested braced if-expression compiles");
 
     let mut shapes = Vec::new();
     let function = compiled
@@ -1105,9 +1102,8 @@ if (ke > 0.5) {{
 }}
 "#
         );
-        let model = parse_model(&src).unwrap_or_else(|err| {
-            panic!("variant {variant:?} failed: {}", err.render(&src))
-        });
+        let model = parse_model(&src)
+            .unwrap_or_else(|err| panic!("variant {variant:?} failed: {}", err.render(&src)));
         let analyzed = analyze_model(&model).expect("model analyzes");
         let compiled = compile_analyzed_model(&analyzed).expect("model compiles");
 
@@ -1186,9 +1182,8 @@ if (ke > 0.5) {{
 }}
 "#
         );
-        let model = parse_model(&src).unwrap_or_else(|err| {
-            panic!("variant {variant:?} failed: {}", err.render(&src))
-        });
+        let model = parse_model(&src)
+            .unwrap_or_else(|err| panic!("variant {variant:?} failed: {}", err.render(&src)));
         let analyzed = analyze_model(&model).expect("model analyzes");
         let compiled = compile_analyzed_model(&analyzed).expect("model compiles");
 
@@ -1349,7 +1344,10 @@ out(cp) = if (ke > 0.5) central / v else central / (2 * v)
                     assert!(
                         matches!(
                             value.kind,
-                            ExecutionExprKind::Binary { op: AnalyzedBinaryOp::Div, .. }
+                            ExecutionExprKind::Binary {
+                                op: AnalyzedBinaryOp::Div,
+                                ..
+                            }
                         ),
                         "branch value must be a division expression"
                     );
@@ -1432,11 +1430,7 @@ fn deeply_nested_statement_ifs_fail_cleanly() {
     }
     let err = parse_model(&src).expect_err("deeply nested statement ifs must fail cleanly");
     let rendered = err.render(&src);
-    assert!(
-        rendered.contains("nested too deeply"),
-        "{}",
-        rendered
-    );
+    assert!(rendered.contains("nested too deeply"), "{}", rendered);
 }
 
 #[test]
@@ -1460,8 +1454,8 @@ out(cp) = central / v_eff
 "#;
     let model = parse_model(src).expect("multi-assignment conditional PK parses");
     let analyzed = analyze_model(&model).expect("multi-assignment conditional PK analyzes");
-    let compiled = compile_analyzed_model(&analyzed)
-        .expect("multi-assignment conditional PK compiles");
+    let compiled =
+        compile_analyzed_model(&analyzed).expect("multi-assignment conditional PK compiles");
 
     let mut shapes = Vec::new();
     let function = compiled

--- a/pharmsol-dsl/tests/dsl_authoring_edge_cases.rs
+++ b/pharmsol-dsl/tests/dsl_authoring_edge_cases.rs
@@ -1374,3 +1374,67 @@ out(cp) = if (ke > 0.5) central / v else central / (2 * v)
          (`central / v` vs `central / (2 * v)`)"
     );
 }
+
+#[test]
+fn then_branch_trailing_tokens_are_rejected() {
+    let src = r#"
+name = then_trailing_tokens
+kind = ode
+states = central
+params = ke, v
+ddt(central) = -ke * central
+out(cp) = if (ke > 0.5) {
+    central / v
+} + 123 else {
+    central / (2 * v)
+}
+"#;
+    let err = parse_model(src).expect_err("tokens after the then body must be rejected");
+    let rendered = err.render(src);
+    assert!(
+        rendered.contains("unexpected tokens after `if`/`else` expression"),
+        "{}",
+        rendered
+    );
+}
+
+#[test]
+fn then_branch_garbage_before_else_is_rejected() {
+    let src = r#"
+name = then_garbage
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+x = if (ke > 0.5) { 1 } garbage else { 2 }
+"#;
+    let err = parse_model(src).expect_err("garbage between then body and else must be rejected");
+    let rendered = err.render(src);
+    assert!(
+        rendered.contains("unexpected tokens after `if`/`else` expression"),
+        "{}",
+        rendered
+    );
+}
+
+#[test]
+fn deeply_nested_statement_ifs_fail_cleanly() {
+    let mut src = String::from(
+        "name = deep_statement_ifs\nkind = ode\nstates = central\nparams = ke\nddt(central) = -ke * central\n",
+    );
+    let nesting = pharmsol_dsl::MAX_NESTING_DEPTH + 2;
+    for _ in 0..nesting {
+        src.push_str("if (ke > 0.5) {\n");
+    }
+    src.push_str("x = 1\n");
+    for _ in 0..nesting {
+        src.push_str("}\n");
+    }
+    let err = parse_model(&src).expect_err("deeply nested statement ifs must fail cleanly");
+    let rendered = err.render(&src);
+    assert!(
+        rendered.contains("nested too deeply"),
+        "{}",
+        rendered
+    );
+}

--- a/pharmsol-dsl/tests/dsl_authoring_edge_cases.rs
+++ b/pharmsol-dsl/tests/dsl_authoring_edge_cases.rs
@@ -1438,3 +1438,66 @@ fn deeply_nested_statement_ifs_fail_cleanly() {
         rendered
     );
 }
+
+#[test]
+fn statement_if_multi_assignment_branches_feed_downstream_pk() {
+    let src = r#"
+name = conditional_pk
+kind = ode
+states = central
+params = cl, v, wt
+
+if (wt > 70) {
+    cl_eff = cl * 1.2
+    v_eff = v * 1.1
+} else {
+    cl_eff = cl
+    v_eff = v
+}
+
+ddt(central) = -(cl_eff / v_eff) * central
+out(cp) = central / v_eff
+"#;
+    let model = parse_model(src).expect("multi-assignment conditional PK parses");
+    let analyzed = analyze_model(&model).expect("multi-assignment conditional PK analyzes");
+    let compiled = compile_analyzed_model(&analyzed)
+        .expect("multi-assignment conditional PK compiles");
+
+    let mut shapes = Vec::new();
+    let function = compiled
+        .function(pharmsol_dsl::execution::ModelFunctionKind::Derive)
+        .expect("derive function");
+    if let pharmsol_dsl::execution::FunctionBody::Statements(program) = &function.body {
+        collect_if_branch_lens(&program.body.statements, &mut shapes);
+    }
+    assert_eq!(
+        shapes,
+        vec![(2, Some(2))],
+        "one if with exactly two assignments per branch"
+    );
+}
+
+#[test]
+fn statement_if_without_else_fails_definite_assignment_analysis() {
+    let src = r#"
+name = conditional_pk_missing_else
+kind = ode
+states = central
+params = cl, v, wt
+
+if (wt > 70) {
+    cl_eff = cl * 1.2
+}
+
+ddt(central) = -(cl_eff / v) * central
+out(cp) = central / v
+"#;
+    let model = parse_model(src).expect("if without else parses");
+    let err = analyze_model(&model).expect_err("conditionally assigned derived must fail analysis");
+    let rendered = err.render(src);
+    assert!(
+        rendered.contains("derived value `cl_eff` is not definitely assigned"),
+        "{}",
+        rendered
+    );
+}

--- a/pharmsol-dsl/tests/dsl_authoring_edge_cases.rs
+++ b/pharmsol-dsl/tests/dsl_authoring_edge_cases.rs
@@ -794,3 +794,290 @@ out(cp) = central / v ~ continuous()
         rendered
     );
 }
+
+fn collect_if_branch_lens(
+    statements: &[pharmsol_dsl::execution::ExecutionStmt],
+    out: &mut Vec<(usize, Option<usize>)>,
+) {
+    use pharmsol_dsl::execution::ExecutionStmtKind;
+    for statement in statements {
+        match &statement.kind {
+            ExecutionStmtKind::If(if_stmt) => {
+                out.push((
+                    if_stmt.then_branch.len(),
+                    if_stmt.else_branch.as_ref().map(|branch| branch.len()),
+                ));
+                collect_if_branch_lens(&if_stmt.then_branch, out);
+                if let Some(else_branch) = &if_stmt.else_branch {
+                    collect_if_branch_lens(else_branch, out);
+                }
+            }
+            ExecutionStmtKind::For(for_stmt) => {
+                collect_if_branch_lens(&for_stmt.body, out);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn statement_level_if_with_braces_parses_and_lowers() {
+    let src = r#"
+name = braced_if_statement
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+if (ke > 0.5) {
+    x = 1
+} else {
+    x = 2
+}
+"#;
+    let model = parse_model(src).expect("braced if authoring model parses");
+    let analyzed = analyze_model(&model).expect("braced if model analyzes");
+    let compiled =
+        compile_analyzed_model(&analyzed).expect("braced if model compiles");
+
+    let mut shapes = Vec::new();
+    let function = compiled
+        .function(pharmsol_dsl::execution::ModelFunctionKind::Derive)
+        .expect("dynamics function");
+    if let pharmsol_dsl::execution::FunctionBody::Statements(program) = &function.body {
+        collect_if_branch_lens(&program.body.statements, &mut shapes);
+    }
+    assert_eq!(shapes, vec![(1, Some(1))], "one if with one stmt per branch");
+}
+
+#[test]
+fn else_if_chain_lowers_to_nested_if() {
+    let src = r#"
+name = else_if_chain
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+if (ke > 1) {
+    x = 1
+} else if (ke > 0.5) {
+    x = 2
+} else {
+    x = 3
+}
+"#;
+    let model = parse_model(src).expect("else-if chain parses");
+    let analyzed = analyze_model(&model).expect("else-if chain analyzes");
+    let compiled =
+        compile_analyzed_model(&analyzed).expect("else-if chain compiles");
+
+    let mut shapes = Vec::new();
+    let function = compiled
+        .function(pharmsol_dsl::execution::ModelFunctionKind::Derive)
+        .expect("dynamics function");
+    if let pharmsol_dsl::execution::FunctionBody::Statements(program) = &function.body {
+        collect_if_branch_lens(&program.body.statements, &mut shapes);
+    }
+    // outer if: then 1, else 1 (nested if); nested if: then 1, else 1
+    assert_eq!(
+        shapes,
+        vec![(1, Some(1)), (1, Some(1))],
+        "outer if nests an inner if in its else branch"
+    );
+}
+
+#[test]
+fn single_line_braced_if_expression_lowers() {
+    let src = r#"
+name = braced_if_expression
+kind = ode
+states = central
+params = ke, v
+ddt(central) = -ke * central
+out(cp) = if (ke > 0.5) { central / v } else { central / (2 * v) }
+"#;
+    let model = parse_model(src).expect("braced if-expression parses");
+    let analyzed = analyze_model(&model).expect("braced if-expression analyzes");
+    let compiled =
+        compile_analyzed_model(&analyzed).expect("braced if-expression compiles");
+
+    let mut shapes = Vec::new();
+    let function = compiled
+        .function(pharmsol_dsl::execution::ModelFunctionKind::Outputs)
+        .expect("outputs function");
+    if let pharmsol_dsl::execution::FunctionBody::Statements(program) = &function.body {
+        collect_if_branch_lens(&program.body.statements, &mut shapes);
+    }
+    assert_eq!(shapes, vec![(1, Some(1))], "if-expression lowers to if");
+}
+
+#[test]
+fn statement_level_if_requires_braces() {
+    let src = r#"
+name = unbraced_if
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+if (ke > 0.5)
+    out(cp) = central
+"#;
+    let model = parse_model(src).expect_err("unbraced if must be rejected");
+    let rendered = model.render(src);
+    assert!(
+        rendered.contains("expected `{` to open `if`/`else` body"),
+        "{}",
+        rendered
+    );
+}
+
+#[test]
+fn unclosed_if_brace_is_rejected() {
+    let src = r#"
+name = unclosed_if
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+if (ke > 0.5) {
+    out(cp) = central
+"#;
+    let model = parse_model(src).expect_err("unclosed brace must be rejected");
+    let rendered = model.render(src);
+    assert!(
+        rendered.contains("unclosed `{` in `if`/`else` body"),
+        "{}",
+        rendered
+    );
+}
+
+#[test]
+fn single_line_statement_level_if_parses() {
+    let src = r#"
+name = single_line_if
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+if (ke > 0.5) { x = 1 } else { x = 2 }
+"#;
+    let model = parse_model(src).expect("single-line statement if parses");
+    let analyzed = analyze_model(&model).expect("single-line statement if analyzes");
+    let compiled =
+        compile_analyzed_model(&analyzed).expect("single-line statement if compiles");
+
+    let mut shapes = Vec::new();
+    let function = compiled
+        .function(pharmsol_dsl::execution::ModelFunctionKind::Derive)
+        .expect("derive function");
+    if let pharmsol_dsl::execution::FunctionBody::Statements(program) = &function.body {
+        collect_if_branch_lens(&program.body.statements, &mut shapes);
+    }
+    assert_eq!(shapes, vec![(1, Some(1))]);
+}
+
+#[test]
+fn multi_line_if_expression_in_assignment_lowers() {
+    let src = r#"
+name = multiline_if_expression
+kind = ode
+states = central
+params = ke, v
+ddt(central) = -ke * central
+out(cp) = if (ke > 0.5) {
+    central / v
+} else {
+    central / (2 * v)
+}
+"#;
+    let model = parse_model(src).expect("multi-line if-expression parses");
+    let analyzed = analyze_model(&model).expect("multi-line if-expression analyzes");
+    let compiled =
+        compile_analyzed_model(&analyzed).expect("multi-line if-expression compiles");
+
+    let mut shapes = Vec::new();
+    let function = compiled
+        .function(pharmsol_dsl::execution::ModelFunctionKind::Outputs)
+        .expect("outputs function");
+    if let pharmsol_dsl::execution::FunctionBody::Statements(program) = &function.body {
+        collect_if_branch_lens(&program.body.statements, &mut shapes);
+    }
+    assert_eq!(shapes, vec![(1, Some(1))]);
+}
+
+#[test]
+fn comment_line_inside_multiline_if_block_does_not_truncate() {
+    let src = r#"
+name = commented_if_block
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+if (ke > 0.5) {
+    # keep this comment; it must not swallow the rest of the block
+    x = 1
+} else {
+    x = 2
+}
+"#;
+    let model = parse_model(src).expect("commented if block parses");
+    let analyzed = analyze_model(&model).expect("commented if block analyzes");
+    let compiled =
+        compile_analyzed_model(&analyzed).expect("commented if block compiles");
+
+    let mut shapes = Vec::new();
+    let function = compiled
+        .function(pharmsol_dsl::execution::ModelFunctionKind::Derive)
+        .expect("derive function");
+    if let pharmsol_dsl::execution::FunctionBody::Statements(program) = &function.body {
+        collect_if_branch_lens(&program.body.statements, &mut shapes);
+    }
+    assert_eq!(shapes, vec![(1, Some(1))]);
+}
+
+#[test]
+fn nested_braced_if_expression_associates_outer_else() {
+    let src = r#"
+name = nested_braced_if_expression
+kind = ode
+states = central
+params = ka, kb
+ddt(central) = -ka * central
+out(cp) = if (ka > 1) { if (kb > 0.5) { 1 } else { 2 } } else { 3 }
+"#;
+    let model = parse_model(src).expect("nested braced if-expression parses");
+    let analyzed = analyze_model(&model).expect("nested braced if-expression analyzes");
+    let compiled = compile_analyzed_model(&analyzed)
+        .expect("nested braced if-expression compiles");
+
+    let mut shapes = Vec::new();
+    let function = compiled
+        .function(pharmsol_dsl::execution::ModelFunctionKind::Outputs)
+        .expect("outputs function");
+    if let pharmsol_dsl::execution::FunctionBody::Statements(program) = &function.body {
+        collect_if_branch_lens(&program.body.statements, &mut shapes);
+    }
+    assert_eq!(
+        shapes,
+        vec![(1, Some(1)), (1, Some(1))],
+        "outer if wraps the inner if; both have one stmt per branch"
+    );
+}
+
+#[test]
+fn trailing_tokens_after_braced_else_body_are_rejected() {
+    let src = r#"
+name = trailing_else_tokens
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+out(cp) = if (ke > 0.5) { 1 } else { 2 } + 3
+"#;
+    let err = parse_model(src).expect_err("trailing tokens after else body must fail");
+    let rendered = err.render(src);
+    assert!(
+        rendered.contains("unexpected tokens after `if`/`else` expression"),
+        "{}",
+        rendered
+    );
+}

--- a/pharmsol-dsl/tests/dsl_authoring_edge_cases.rs
+++ b/pharmsol-dsl/tests/dsl_authoring_edge_cases.rs
@@ -1310,3 +1310,67 @@ if (ke > 0.5) {
         rendered
     );
 }
+
+#[test]
+fn legacy_unbraced_if_expression_rhs_parses_and_lowers() {
+    // The unbraced `if (cond) a else b` conditional-expression form predates
+    // PR #330 and must keep working alongside the new braced form.
+    let src = r#"
+name = legacy_if_expression
+kind = ode
+states = central
+params = ke, v
+ddt(central) = -ke * central
+out(cp) = if (ke > 0.5) central / v else central / (2 * v)
+"#;
+    let model = parse_model(src).expect("legacy unbraced if-expression parses");
+    let analyzed = analyze_model(&model).expect("model analyzes");
+    let compiled = compile_analyzed_model(&analyzed).expect("model compiles");
+
+    use pharmsol_dsl::execution::{
+        ExecutionExprKind, ExecutionStmtKind, FunctionBody, ModelFunctionKind,
+    };
+    use pharmsol_dsl::AnalyzedBinaryOp;
+
+    let mut shapes = Vec::new();
+    let mut branch_values = Vec::new();
+    let function = compiled
+        .function(ModelFunctionKind::Outputs)
+        .expect("outputs function");
+    if let FunctionBody::Statements(program) = &function.body {
+        collect_if_branch_lens(&program.body.statements, &mut shapes);
+        for statement in &program.body.statements {
+            if let ExecutionStmtKind::If(if_stmt) = &statement.kind {
+                for branch in [&if_stmt.then_branch, if_stmt.else_branch.as_ref().unwrap()] {
+                    let value = match &branch[0].kind {
+                        ExecutionStmtKind::Assign(assign) => &assign.value,
+                        _ => panic!("branch statement is not an assignment"),
+                    };
+                    assert!(
+                        matches!(
+                            value.kind,
+                            ExecutionExprKind::Binary { op: AnalyzedBinaryOp::Div, .. }
+                        ),
+                        "branch value must be a division expression"
+                    );
+                    branch_values.push(value.clone());
+                }
+            }
+        }
+    }
+    assert_eq!(
+        shapes,
+        vec![(1, Some(1))],
+        "legacy form must lower to one if with one stmt per branch"
+    );
+    assert_eq!(
+        branch_values.len(),
+        2,
+        "conditional must have both a then and an else value"
+    );
+    assert_ne!(
+        branch_values[0], branch_values[1],
+        "then and else branches must carry the distinct conditional values \
+         (`central / v` vs `central / (2 * v)`)"
+    );
+}

--- a/pharmsol-dsl/tests/dsl_authoring_edge_cases.rs
+++ b/pharmsol-dsl/tests/dsl_authoring_edge_cases.rs
@@ -1081,3 +1081,232 @@ out(cp) = if (ke > 0.5) { 1 } else { 2 } + 3
         rendered
     );
 }
+
+#[test]
+fn else_on_own_line_or_after_trivia_lines_parses() {
+    let variants = [
+        "} else {",
+        "}\nelse {",
+        "}\n\nelse {",
+        "}\n# explanation\nelse {",
+    ];
+    for (i, variant) in variants.iter().enumerate() {
+        let src = format!(
+            r#"
+name = trivia_else_{i}
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+if (ke > 0.5) {{
+    x = 1
+{variant}
+    x = 2
+}}
+"#
+        );
+        let model = parse_model(&src).unwrap_or_else(|err| {
+            panic!("variant {variant:?} failed: {}", err.render(&src))
+        });
+        let analyzed = analyze_model(&model).expect("model analyzes");
+        let compiled = compile_analyzed_model(&analyzed).expect("model compiles");
+
+        let mut shapes = Vec::new();
+        let function = compiled
+            .function(pharmsol_dsl::execution::ModelFunctionKind::Derive)
+            .expect("dynamics function");
+        if let pharmsol_dsl::execution::FunctionBody::Statements(program) = &function.body {
+            collect_if_branch_lens(&program.body.statements, &mut shapes);
+        }
+        assert_eq!(shapes, vec![(1, Some(1))], "variant {variant:?}");
+    }
+}
+
+#[test]
+fn else_if_chain_with_blank_and_comment_lines_parses() {
+    let src = r#"
+name = chain_with_trivia
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+if (ke > 1) {
+    x = 1
+}
+
+else if (ke > 0.5) {
+    x = 2
+}
+
+# a comment sitting between the chain links
+else {
+    x = 3
+}
+"#;
+    let model = parse_model(src).expect("else-if chain with trivia parses");
+    let analyzed = analyze_model(&model).expect("model analyzes");
+    let compiled = compile_analyzed_model(&analyzed).expect("model compiles");
+
+    let mut shapes = Vec::new();
+    let function = compiled
+        .function(pharmsol_dsl::execution::ModelFunctionKind::Derive)
+        .expect("dynamics function");
+    if let pharmsol_dsl::execution::FunctionBody::Statements(program) = &function.body {
+        collect_if_branch_lens(&program.body.statements, &mut shapes);
+    }
+    assert_eq!(
+        shapes,
+        vec![(1, Some(1)), (1, Some(1))],
+        "outer if nests an inner if in its else branch"
+    );
+}
+
+#[test]
+fn nested_statement_if_else_across_lines_parses() {
+    let variants = [
+        "} else {",
+        "}\nelse {",
+        "}\n\nelse {",
+        "}\n    # explanation\n    else {",
+    ];
+    for (i, variant) in variants.iter().enumerate() {
+        let src = format!(
+            r#"
+name = nested_if_else_{i}
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+if (ke > 0.5) {{
+    if (ke > 1) {{
+        x = 1
+    {variant}
+        x = 2
+    }}
+}}
+"#
+        );
+        let model = parse_model(&src).unwrap_or_else(|err| {
+            panic!("variant {variant:?} failed: {}", err.render(&src))
+        });
+        let analyzed = analyze_model(&model).expect("model analyzes");
+        let compiled = compile_analyzed_model(&analyzed).expect("model compiles");
+
+        let mut shapes = Vec::new();
+        let function = compiled
+            .function(pharmsol_dsl::execution::ModelFunctionKind::Derive)
+            .expect("dynamics function");
+        if let pharmsol_dsl::execution::FunctionBody::Statements(program) = &function.body {
+            collect_if_branch_lens(&program.body.statements, &mut shapes);
+        }
+        assert_eq!(
+            shapes,
+            vec![(1, None), (1, Some(1))],
+            "outer if holds the nested if; nested if has one stmt per branch (variant {variant:?})"
+        );
+    }
+}
+
+#[test]
+fn inline_comments_in_statement_if_branches_parse() {
+    let src = r#"
+name = inline_comments_if
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+if (ke > 0.5) {
+    x = 1 # then-branch comment
+} else {
+    x = 2 # else-branch comment
+} # trailing comment after the closing brace
+"#;
+    let model = parse_model(src).expect("inline comments in if branches parse");
+    let analyzed = analyze_model(&model).expect("model analyzes");
+    let compiled = compile_analyzed_model(&analyzed).expect("model compiles");
+
+    let mut shapes = Vec::new();
+    let function = compiled
+        .function(pharmsol_dsl::execution::ModelFunctionKind::Derive)
+        .expect("dynamics function");
+    if let pharmsol_dsl::execution::FunctionBody::Statements(program) = &function.body {
+        collect_if_branch_lens(&program.body.statements, &mut shapes);
+    }
+    assert_eq!(shapes, vec![(1, Some(1))]);
+}
+
+#[test]
+fn trailing_tokens_after_statement_else_body_are_rejected() {
+    let src = r#"
+name = trailing_statement_else_tokens
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+if (ke > 0.5) {
+    x = 1
+} else {
+    x = 2
+} garbage
+"#;
+    let err = parse_model(src).expect_err("trailing tokens after statement else body must fail");
+    let rendered = err.render(src);
+    assert!(
+        rendered.contains("unexpected tokens after `if`/`else` statement"),
+        "{}",
+        rendered
+    );
+}
+
+#[test]
+fn diagnostic_positions_survive_earlier_inline_comments() {
+    let src = r#"
+name = diag_positions
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+if (ke > 0.5) {
+    x = 1 # a long inline comment that used to shift later spans: pad pad pad pad pad pad pad
+    y = 
+}
+"#;
+    let err = parse_model(src).expect_err("empty rhs inside if body must be rejected");
+    let rendered = err.render(src);
+    assert!(
+        rendered.contains("expected `name = <expression>`"),
+        "{}",
+        rendered
+    );
+    assert!(
+        rendered.contains("--> line 9, column 5"),
+        "diagnostic must point at the `y =` line, got:\n{}",
+        rendered
+    );
+}
+
+#[test]
+fn call_style_assignment_inside_statement_if_is_rejected() {
+    let src = r#"
+name = call_style_if_body
+kind = ode
+states = central
+params = ke
+ddt(central) = -ke * central
+if (ke > 0.5) {
+    ddt(central) = -2 * ke * central
+}
+"#;
+    let err = parse_model(src).expect_err("call-style assignment in if body must be rejected");
+    let rendered = err.render(src);
+    assert!(
+        rendered.contains("only plain-variable assignments"),
+        "{}",
+        rendered
+    );
+    assert!(
+        rendered.contains("ddt(central) = if (cond) <a> else <b>"),
+        "{}",
+        rendered
+    );
+}


### PR DESCRIPTION
This PR adds support for `if` statements and `if` expressions in the DSL.

Both one-line expressions and multi-line block syntax are supported.

### If expressions

One-line:

```text
ke_eff = if (wt > 70) ke * 1.2 else ke
```

Block form:

```text
ke_eff = if (wt > 70) {
    ke * 1.2
} else {
    ke
}
```

### If statements

```text
if (wt > 70) {
    cl_eff = cl * 1.2
    v_eff = v * 1.1
} else {
    cl_eff = cl
    v_eff = v
}
```

`else if` chains and nested conditionals are also supported.

Existing one-line `if` expressions remain backwards compatible.
