### PR TITLE
fix: numeric equality in DSL

### DIFF
--- a/pharmsol-dsl/src/analyze.rs
+++ b/pharmsol-dsl/src/analyze.rs
@@ -1523,16 +1523,19 @@ impl<'a> Analyzer<'a> {
                 Ok(ValueType::Bool)
             }
             AnalyzedBinaryOp::Eq | AnalyzedBinaryOp::NotEq => {
-                if lhs.ty != rhs.ty {
-                    return Err(AnalysisError::new(
+                if (lhs.ty.is_numeric() && rhs.ty.is_numeric())
+                    || (lhs.ty == ValueType::Bool && rhs.ty == ValueType::Bool)
+                {
+                    Ok(ValueType::Bool)
+                } else {
+                    Err(AnalysisError::new(
                         format!(
-                            "equality comparison requires matching operand types, found {:?} and {:?}",
+                            "equality comparison cannot mix boolean and numeric operands, found {:?} and {:?}",
                             lhs.ty, rhs.ty
                         ),
                         span,
-                    ));
+                    ))
                 }
-                Ok(ValueType::Bool)
             }
             AnalyzedBinaryOp::Lt
             | AnalyzedBinaryOp::LtEq
@@ -2835,8 +2838,21 @@ fn fold_binary(op: AnalyzedBinaryOp, lhs: &ConstValue, rhs: &ConstValue) -> Opti
         AnalyzedBinaryOp::And => Some(ConstValue::Bool(
             matches!(lhs, ConstValue::Bool(true)) && matches!(rhs, ConstValue::Bool(true)),
         )),
-        AnalyzedBinaryOp::Eq => Some(ConstValue::Bool(lhs == rhs)),
-        AnalyzedBinaryOp::NotEq => Some(ConstValue::Bool(lhs != rhs)),
+        AnalyzedBinaryOp::Eq | AnalyzedBinaryOp::NotEq => {
+            let equal = match (lhs, rhs) {
+                (ConstValue::Bool(lhs), ConstValue::Bool(rhs)) => lhs == rhs,
+                (ConstValue::Int(lhs), ConstValue::Int(rhs)) => lhs == rhs,
+                (lhs, rhs) if lhs.value_type().is_numeric() && rhs.value_type().is_numeric() => {
+                    lhs.as_f64()? == rhs.as_f64()?
+                }
+                _ => return None,
+            };
+            Some(ConstValue::Bool(match op {
+                AnalyzedBinaryOp::Eq => equal,
+                AnalyzedBinaryOp::NotEq => !equal,
+                _ => unreachable!(),
+            }))
+        }
         AnalyzedBinaryOp::Lt => Some(ConstValue::Bool(lhs.as_f64()? < rhs.as_f64()?)),
         AnalyzedBinaryOp::LtEq => Some(ConstValue::Bool(lhs.as_f64()? <= rhs.as_f64()?)),
         AnalyzedBinaryOp::Gt => Some(ConstValue::Bool(lhs.as_f64()? > rhs.as_f64()?)),

--- a/pharmsol-dsl/src/analyze.rs
+++ b/pharmsol-dsl/src/analyze.rs
@@ -1530,7 +1530,7 @@ impl<'a> Analyzer<'a> {
                 } else {
                     Err(AnalysisError::new(
                         format!(
-                            "equality comparison cannot mix boolean and numeric operands, found {:?} and {:?}",
+                            "cannot compare boolean and numeric operands, found {:?} and {:?}",
                             lhs.ty, rhs.ty
                         ),
                         span,

--- a/pharmsol-dsl/tests/frontend_hardening.rs
+++ b/pharmsol-dsl/tests/frontend_hardening.rs
@@ -200,6 +200,93 @@ fn constant_two_to_the_63_stays_real() {
 }
 
 #[test]
+fn equality_analyzes_mixed_numeric_operands_in_both_directions() {
+    let src = r#"
+model m {
+    kind ode
+    covariates { drug }
+    states { central }
+    dynamics { ddt(central) = 0 }
+    outputs {
+        if drug == 1 {
+            cp = 1
+        } else if 1 != drug {
+            cp = 2
+        } else if 1.1 == drug {
+            cp = 3
+        } else {
+            cp = 4
+        }
+    }
+}
+"#;
+
+    let model = parse_model(src).expect("model parses");
+    analyze_model(&model).expect("mixed numeric equality analyzes");
+}
+
+#[test]
+fn equality_accepts_bool_operands_and_folds_exactly() {
+    let src = ode_with_constants("equal = true == true, not_equal = true != false");
+
+    assert_eq!(analyzed_constant(&src, "equal"), ConstValue::Bool(true));
+    assert_eq!(analyzed_constant(&src, "not_equal"), ConstValue::Bool(true));
+
+    let src = r#"
+model m {
+    kind ode
+    states { central }
+    dynamics { ddt(central) = 0 }
+    outputs {
+        if true == false {
+            cp = 1
+        } else {
+            cp = 2
+        }
+    }
+}
+"#;
+    let model = parse_model(src).expect("model parses");
+    analyze_model(&model).expect("bool equality analyzes");
+}
+
+#[test]
+fn equality_rejects_bool_numeric_operands() {
+    for expression in ["true == 1", "1 != false"] {
+        let src = format!(
+            "model m {{ kind ode states {{ central }} dynamics {{ ddt(central) = 0 }} outputs {{ if {expression} {{ cp = 1 }} else {{ cp = 2 }} }} }}"
+        );
+        let model = parse_model(&src).expect("model parses");
+        let error = analyze_model(&model).expect_err("bool/numeric equality must fail");
+        let rendered = error.render(&src);
+        assert!(
+            rendered.contains("boolean and numeric operands"),
+            "{rendered}"
+        );
+    }
+}
+
+#[test]
+fn equality_constant_folding_preserves_numeric_operand_types() {
+    let src = ode_with_constants(
+        "real_one = 1 / 1, mixed_eq = 1 == real_one, mixed_neq = 1 != real_one, large_left = 9007199254740992, large_right = large_left + 1, large_eq = large_left == large_right, large_neq = large_left != large_right",
+    );
+
+    assert_eq!(analyzed_constant(&src, "real_one"), ConstValue::Real(1.0));
+    assert_eq!(analyzed_constant(&src, "mixed_eq"), ConstValue::Bool(true));
+    assert_eq!(
+        analyzed_constant(&src, "mixed_neq"),
+        ConstValue::Bool(false)
+    );
+    assert_eq!(
+        analyzed_constant(&src, "large_right"),
+        ConstValue::Int(9_007_199_254_740_993)
+    );
+    assert_eq!(analyzed_constant(&src, "large_eq"), ConstValue::Bool(false));
+    assert_eq!(analyzed_constant(&src, "large_neq"), ConstValue::Bool(true));
+}
+
+#[test]
 fn compile_time_calls_enforce_intrinsic_arity() {
     for (call, message) in [
         (

--- a/src/dsl/jit.rs
+++ b/src/dsl/jit.rs
@@ -824,7 +824,7 @@ fn lower_binary(
             })
         }
         AnalyzedBinaryOp::Eq | AnalyzedBinaryOp::NotEq => {
-            let value = lower_equality(builder, lhs, rhs, target_ty, op, span)?;
+            let value = lower_equality(builder, lhs, rhs, op, span)?;
             Ok(LoweredValue {
                 value,
                 ty: ValueType::Bool,
@@ -1010,7 +1010,6 @@ fn lower_equality(
     builder: &mut FunctionBuilder<'_>,
     lhs: LoweredValue,
     rhs: LoweredValue,
-    target_ty: ValueType,
     op: AnalyzedBinaryOp,
     span: Span,
 ) -> Result<Value, JitCompileError> {
@@ -1019,8 +1018,15 @@ fn lower_equality(
         AnalyzedBinaryOp::NotEq => false,
         _ => unreachable!(),
     };
+    let operand_ty = if lhs.ty == ValueType::Real || rhs.ty == ValueType::Real {
+        ValueType::Real
+    } else if lhs.ty == ValueType::Bool && rhs.ty == ValueType::Bool {
+        ValueType::Bool
+    } else {
+        ValueType::Int
+    };
 
-    let comparison = match target_ty {
+    let comparison = match operand_ty {
         ValueType::Real => {
             let lhs = cast_value(builder, lhs, ValueType::Real, span)?;
             let rhs = cast_value(builder, rhs, ValueType::Real, span)?;
@@ -1035,8 +1041,8 @@ fn lower_equality(
             )
         }
         ValueType::Int | ValueType::Bool => {
-            let lhs = cast_value(builder, lhs, target_ty, span)?;
-            let rhs = cast_value(builder, rhs, target_ty, span)?;
+            let lhs = cast_value(builder, lhs, operand_ty, span)?;
+            let rhs = cast_value(builder, rhs, operand_ty, span)?;
             builder.ins().icmp(
                 if predicate {
                     IntCC::Equal

--- a/tests/dsl_numeric_equality.rs
+++ b/tests/dsl_numeric_equality.rs
@@ -1,0 +1,117 @@
+//! Regression coverage for numeric equality in the DSL runtime.
+
+#![cfg(any(
+    feature = "dsl-jit",
+    all(feature = "dsl-aot", feature = "dsl-aot-load")
+))]
+
+use pharmsol::dsl::{
+    compile_module_source_to_runtime, CompiledRuntimeModel, RuntimeCompilationTarget,
+};
+use pharmsol::{prelude::*, Parameters};
+
+const MODEL_SOURCE: &str = r#"
+name = numeric_equality
+kind = ode
+
+params = a, b, c
+covariates = drug
+states = central
+outputs = e, non_integral, not_one
+
+dx(central) = 0
+
+out(e) = if (drug == 1) a else if (drug == 2) b else c
+out(non_integral) = if (drug == 1.1) a else if (drug == 2.1) b else c
+out(not_one) = if (drug != 1) a else b
+"#;
+
+fn output_value(model: &CompiledRuntimeModel, drug: f64, output: &str) -> f64 {
+    let parameters = Parameters::with_model(model, [("a", 10.0), ("b", 20.0), ("c", 30.0)])
+        .expect("valid named parameters");
+    let subject = Subject::builder("numeric-equality")
+        .covariate("drug", 0.0, drug)
+        .missing_observation(0.0, output)
+        .build();
+
+    model
+        .estimate_predictions(&subject, &parameters)
+        .expect("predictions succeed")
+        .into_subject()
+        .expect("ODE predictions are subject predictions")
+        .predictions()
+        .first()
+        .expect("one output prediction")
+        .prediction()
+}
+
+fn assert_numeric_equality_results(model: &CompiledRuntimeModel) {
+    for (drug, expected) in [(1.0, 10.0), (2.0, 20.0), (3.0, 30.0)] {
+        assert_eq!(output_value(model, drug, "e"), expected, "drug={drug}");
+    }
+
+    for (drug, expected) in [
+        (1.0, 30.0),
+        (2.0, 30.0),
+        (3.0, 30.0),
+        (1.1, 10.0),
+        (2.1, 20.0),
+        (3.1, 30.0),
+    ] {
+        assert_eq!(
+            output_value(model, drug, "non_integral"),
+            expected,
+            "drug={drug}"
+        );
+    }
+
+    for (drug, expected) in [
+        (1.0, 20.0),
+        (2.0, 10.0),
+        (3.0, 10.0),
+        (1.1, 10.0),
+        (2.1, 10.0),
+        (3.1, 10.0),
+    ] {
+        assert_eq!(
+            output_value(model, drug, "not_one"),
+            expected,
+            "drug={drug}"
+        );
+    }
+}
+
+#[cfg(feature = "dsl-jit")]
+#[test]
+fn numeric_equality_selects_real_covariate_branches_under_jit() {
+    let model = compile_module_source_to_runtime(
+        MODEL_SOURCE,
+        Some("numeric_equality"),
+        RuntimeCompilationTarget::Jit,
+        |_, _| {},
+    )
+    .expect("compile numeric equality model with JIT");
+
+    assert_numeric_equality_results(&model);
+}
+
+#[cfg(all(feature = "dsl-aot", feature = "dsl-aot-load"))]
+#[test]
+fn numeric_equality_matches_native_aot() {
+    use pharmsol::dsl::NativeAotCompileOptions;
+    use tempfile::tempdir;
+
+    let work_dir = tempdir().expect("temporary AOT workspace");
+    let model = compile_module_source_to_runtime(
+        MODEL_SOURCE,
+        Some("numeric_equality"),
+        RuntimeCompilationTarget::NativeAot(
+            NativeAotCompileOptions::new(work_dir.path().join("build"))
+                .with_output(work_dir.path().join("numeric_equality.pkm")),
+        ),
+        |_, _| {},
+    )
+    .expect("compile numeric equality model with native AOT");
+
+    assert_numeric_equality_results(&model);
+}


### PR DESCRIPTION
This PR aims to close #338.

There is an issue in the way the DSL processes float numbers with boolean operators. This PR sets some rules to make it work.